### PR TITLE
Fix for unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ daq_add_application(trgtools_process_tpstream process_tpstream.cxx LINK_LIBRARIE
 
 # See https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/#daq_add_unit_test
 
-daq_add_unit_test(Placeholder_test LINK_LIBRARIES)  # Placeholder_test should be replaced with real unit tests
+daq_add_unit_test(TPGtools_unittest LINK_LIBRARIES)  # Should be replaced with real unit tests
 
 ##############################################################################
 

--- a/unittest/TPGtools_unittest.cxx
+++ b/unittest/TPGtools_unittest.cxx
@@ -1,5 +1,5 @@
 /**
- * @file Placeholder_test.cxx
+ * @file TPGtools_unittest.cxx
  *
  * This file provides a skeleton off of which developers can write
  * unit tests for their package. The file is meant to be renamed as
@@ -11,11 +11,11 @@
  * received with this code.
  */
 
-#define BOOST_TEST_MODULE Placeholder_test // NOLINT
+#define BOOST_TEST_MODULE TPGtools_unittest // NOLINT
 
 #include "boost/test/unit_test.hpp"
 
-BOOST_AUTO_TEST_SUITE(Placeholder_test)
+BOOST_AUTO_TEST_SUITE(TPGtools_unittest)
 
 BOOST_AUTO_TEST_CASE(ReplaceThisTest)
 {


### PR DESCRIPTION
Fix for the unittest as it had the same name as the one in tpgtools and one couldn't build dunedaq with both these repositories. 