### PR TITLE
Processing TAs in Timeslices

### DIFF
--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -15,24 +15,6 @@ import trgtools
 
 TICK_TO_SEC_SCALE = 512e-9 # s per tick
 
-def tp_channel_histogram(tp_data):
-    """
-    Plot the TP channel histogram.
-    """
-    tp_channel = np.zeros((0,))
-    for idx, tp_datum in enumerate(tp_data):
-        tp_channel = np.concatenate((tp_channel, tp_datum['channel']))
-
-    plt.figure(figsize=(6,4))
-
-    plt.hist(tp_channel, bins=np.arange(0.5, 3072.5, 1), color='k')
-
-    plt.title("TP Channel Histogram")
-    plt.xlabel("Channel")
-
-    plt.savefig("tp_channel_histogram.svg")
-    plt.close()
-
 def window_length_hist(window_lengths):
     """
     Plot a histogram of the TA window lengths.

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -15,6 +15,24 @@ import trgtools
 
 TICK_TO_SEC_SCALE = 512e-9 # s per tick
 
+def tp_channel_histogram(tp_data):
+    """
+    Plot the TP channel histogram.
+    """
+    tp_channel = np.zeros((0,))
+    for idx, tp_datum in enumerate(tp_data):
+        tp_channel = np.concatenate((tp_channel, tp_datum['channel']))
+
+    plt.figure(figsize=(6,4))
+
+    plt.hist(tp_channel, bins=np.arange(0.5, 3072.5, 1), color='k')
+
+    plt.title("TP Channel Histogram")
+    plt.xlabel("Channel")
+
+    plt.savefig("tp_channel_histogram.svg")
+    plt.close()
+
 def window_length_hist(window_lengths):
     """
     Plot a histogram of the TA window lengths.
@@ -37,8 +55,6 @@ def num_tps_hist(num_tps):
 
     plt.title("Number of TPs Histogram")
     plt.xlabel("Number of TPs")
-    #plt.xlim((0,500))
-    #plt.ylim((0,200))
 
     plt.savefig("num_tps_histogram.svg")
     plt.close()
@@ -66,6 +82,9 @@ def time_start_plot(start_times):
     plt.close()
 
 def algorithm_hist(algorithms):
+    """
+    Plot a histogram of the algorithm types for each TA.
+    """
     plt.figure(figsize=(12,8))
     plt.hist(np.array(algorithms), bins=np.arange(-0.5, 8, 1), range=(0,7), align='mid', color='k')
 
@@ -84,6 +103,9 @@ def algorithm_hist(algorithms):
     plt.close()
 
 def det_type_hist(det_types):
+    """
+    Plot a histogram of the detector type for the TAs.
+    """
     plt.figure(figsize=(12,8))
     plt.hist(np.array(det_types), bins=np.arange(-0.5, 3, 1), range=(0,2), align='mid', color='k')
 
@@ -96,6 +118,9 @@ def det_type_hist(det_types):
     plt.close()
 
 def adc_integral_hist(adc_integrals):
+    """
+    Plot a histogram of the ADC integrals for the TAs.
+    """
     plt.figure(figsize=(6,4))
     plt.hist(np.array(adc_integrals), color='k')
 
@@ -127,21 +152,13 @@ def all_event_displays(tp_data, run_id, sub_run_id):
             pdf.savefig()
             plt.close()
 
-def start_time_diff_hist(start_times):
-    start_time_diff = (np.array(start_times[1:] + [0]) - np.array(start_times))[:-1]
-    plt.figure(figsize=(6,4))
-
-    plt.hist(start_time_diff, bins=25, color='#63ACBE', label="Start Time Difference", alpha=1.0)
-
-    plt.title("TA Timings Histogram")
-    plt.xlabel("Time Ticks")
-    plt.legend()
-
-    plt.savefig("start_time_diff_histogram.svg")
-    plt.close()
-
 def time_diff_hist(start_times, end_times):
+    """
+    Plot a histogram of the time differences.
+    """
+    # Difference between all the start times.
     start_time_diff = (np.array(start_times[1:] + [0]) - np.array(start_times))[:-1]
+    # Difference between previous TA end time and current TA start time.
     time_gaps = np.array(start_times)[1:] - np.array(end_times)[:-1]
 
     start_time_diff = start_time_diff.astype(np.uint64) * TICK_TO_SEC_SCALE
@@ -159,6 +176,10 @@ def time_diff_hist(start_times, end_times):
     plt.close()
 
 def event_display(peak_times, channels, idx):
+    """
+    Plot an individual event display.
+
+    """
     plt.figure(figsize=(6,4))
 
     plt.scatter(peak_times, channels, c='k', s=2)
@@ -172,7 +193,7 @@ def event_display(peak_times, channels, idx):
     plt.xlabel("Peak Time")
     plt.ylabel("Channel")
 
-    plt.savefig(f"./event_displays/event_display_{idx:03}.svg")
+    plt.savefig(f"./event_display_{idx:03}.svg")
     plt.close()
 
 def parse():
@@ -222,10 +243,11 @@ def main():
     adc_integral_hist(diagnostics["adc_integral"])
     time_start_plot(diagnostics["time_start"])
     time_diff_hist(diagnostics["time_start"], diagnostics["time_end"])
-    start_time_diff_hist(diagnostics["time_start"])
 
     if (not no_displays):
         all_event_displays(data.tp_data, run_id, sub_run_id)
+
+    tp_channel_histogram(data.tp_data)
 
 if __name__ == "__main__":
     main()

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -38,7 +38,7 @@ def window_length_hist(window_lengths):
     Plot a histogram of the TA window lengths.
     """
     plt.figure(figsize=(6,4))
-    plt.hist(np.array(window_lengths, dtype=np.uint64) * TICK_TO_SEC_SCALE, color='k')
+    plt.hist(np.array(window_lengths, dtype=np.uint64).flatten() * TICK_TO_SEC_SCALE, color='k')
 
     plt.title("TA Time Window Length Histogram")
     plt.xlabel("Time Window Length (s)")
@@ -51,7 +51,7 @@ def num_tps_hist(num_tps):
     Plot the number of TPs for each TA as a histogram.
     """
     plt.figure(figsize=(6,4))
-    plt.hist(num_tps, bins=50, color='k')
+    plt.hist(np.array(num_tps).flatten(), bins=50, color='k')
 
     plt.title("Number of TPs Histogram")
     plt.xlabel("Number of TPs")
@@ -59,7 +59,7 @@ def num_tps_hist(num_tps):
     plt.savefig("num_tps_histogram.svg")
     plt.close()
 
-def time_start_plot(start_times):
+def time_start_plot(start_times, frag_index=-1):
     """
     Plot in order the time_start member data for TAs.
     """
@@ -86,7 +86,8 @@ def algorithm_hist(algorithms):
     Plot a histogram of the algorithm types for each TA.
     """
     plt.figure(figsize=(12,8))
-    plt.hist(np.array(algorithms), bins=np.arange(-0.5, 8, 1), range=(0,7), align='mid', color='k')
+    counts, _ , _ = plt.hist(np.array(algorithms).flatten(), bins=np.arange(-0.5, 8, 1), range=(0,7), align='mid', color='k')
+    print(f"Number of TAs: {np.sum(counts).astype(int)}")
 
     plt.title("TA Algorithm Histogram")
     plt.xticks(ticks=range(0,8), labels=("Unknown",
@@ -107,7 +108,7 @@ def det_type_hist(det_types):
     Plot a histogram of the detector type for the TAs.
     """
     plt.figure(figsize=(12,8))
-    plt.hist(np.array(det_types), bins=np.arange(-0.5, 3, 1), range=(0,2), align='mid', color='k')
+    plt.hist(np.array(det_types).flatten(), bins=np.arange(-0.5, 3, 1), range=(0,2), align='mid', color='k')
 
     plt.title("TA Detector Type Histogram")
     plt.xticks(ticks=range(0,3), labels=("Unknown",
@@ -122,7 +123,7 @@ def adc_integral_hist(adc_integrals):
     Plot a histogram of the ADC integrals for the TAs.
     """
     plt.figure(figsize=(6,4))
-    plt.hist(np.array(adc_integrals), color='k')
+    plt.hist(np.array(adc_integrals).flatten(), color='k')
 
     plt.title("TA ADC Integral Histogram")
     plt.xlabel("ADC Integral")
@@ -135,29 +136,30 @@ def all_event_displays(tp_data, run_id, sub_run_id):
     Plot all event_displays as pages in a PDF.
     """
     with PdfPages(f"event_displays_{run_id}.{sub_run_id:04}.pdf") as pdf:
-        for idx, tp_datum in enumerate(tp_data):
-            fig = plt.figure(figsize=(6,4))
+        for fdx, frag in enumerate(tp_data):
+            for tadx, ta in enumerate(frag):
+                fig = plt.figure(figsize=(6,4))
 
-            plt.scatter(tp_datum['time_peak'], tp_datum['channel'], c='k', s=2)
+                plt.scatter(ta['time_peak'], ta['channel'], c='k', s=2)
 
-            max_time = np.max(tp_datum['time_peak'])
-            min_time = np.min(tp_datum['time_peak'])
-            time_diff = max_time - min_time
+                max_time = np.max(ta['time_peak'])
+                min_time = np.min(ta['time_peak'])
+                time_diff = max_time - min_time
 
-            plt.xlim((min_time - 0.1*time_diff, max_time + 0.1*time_diff))
-            plt.title(f'Run {run_id}.{sub_run_id:04} Event Display: {idx:03}')
-            plt.xlabel("Peak Time")
-            plt.ylabel("Channel")
+                plt.xlim((min_time - 0.1*time_diff, max_time + 0.1*time_diff))
+                plt.title(f'Run {run_id}.{sub_run_id:04} Event Display: {fdx:03}.{tadx:03}')
+                plt.xlabel("Peak Time")
+                plt.ylabel("Channel")
 
-            pdf.savefig()
-            plt.close()
+                pdf.savefig()
+                plt.close()
 
 def time_diff_hist(start_times, end_times):
     """
     Plot a histogram of the time differences.
     """
     # Difference between all the start times.
-    start_time_diff = (np.array(start_times[1:] + [0]) - np.array(start_times))[:-1]
+    start_time_diff = (np.concatenate((start_times[1:], [0])) - np.array(start_times))[:-1]
     # Difference between previous TA end time and current TA start time.
     time_gaps = np.array(start_times)[1:] - np.array(end_times)[:-1]
 
@@ -201,6 +203,8 @@ def parse():
     parser.add_argument("filename", help="Absolute path to tpstream file to display.")
     parser.add_argument("--quiet", action="store_true", help="Stops the output of printed information. Default: False.")
     parser.add_argument("--no-displays", action="store_true", help="Stops the processing of event displays.")
+    parser.add_argument("--start-frag", type=int, help="Starting fragment index to process from. Takes negative indexing. Default: -10.", default=-10)
+    parser.add_argument("--end-frag", type=int, help="Fragment index to stop processing (i.e. not inclusive). Takes negative indexing. Default: 0.", default=0)
 
     return parser.parse_args()
 
@@ -210,6 +214,8 @@ def main():
     filename = args.filename
     quiet = args.quiet
     no_displays = args.no_displays
+    start_frag = args.start_frag
+    end_frag = args.end_frag
 
     diagnostics = {
                     "num_tps": [],
@@ -222,18 +228,28 @@ def main():
                   }
 
     data = trgtools.TAData(filename, quiet)
-    data.load_all_frags()
+    if end_frag != 0:
+        frag_paths = data.get_ta_frag_paths()[start_frag:end_frag]
+    elif end_frag == 0:
+        frag_paths = data.get_ta_frag_paths()[start_frag:]
+    for path in frag_paths:
+        data.load_frag(path)
+
     run_id = data.run_id
     sub_run_id = data.sub_run_id
 
-    for ta in data.ta_data:
-        diagnostics["num_tps"].append(ta["num_tps"])
-        diagnostics["window_length"].append(ta["time_end"] - ta["time_start"])
-        diagnostics["algorithm"].append(ta["algorithm"])
-        diagnostics["det_type"].append(ta["type"])
-        diagnostics["adc_integral"].append(ta["adc_integral"])
-        diagnostics["time_start"].append(ta["time_start"])
-        diagnostics["time_end"].append(ta["time_end"])
+    for frag in data.ta_data:
+        for ta in frag:
+            diagnostics["num_tps"].append(ta["num_tps"])
+            diagnostics["window_length"].append(ta["time_end"] - ta["time_start"])
+            diagnostics["algorithm"].append(ta["algorithm"])
+            diagnostics["det_type"].append(ta["type"])
+            diagnostics["adc_integral"].append(ta["adc_integral"])
+            diagnostics["time_start"].append(ta["time_start"])
+            diagnostics["time_end"].append(ta["time_end"])
+
+    if (not quiet):
+        print(f"Number of Fragments: {len(data.ta_data)}")
 
     ## Plotting
     num_tps_hist(diagnostics["num_tps"])
@@ -241,13 +257,11 @@ def main():
     algorithm_hist(diagnostics["algorithm"])
     det_type_hist(diagnostics["det_type"])
     adc_integral_hist(diagnostics["adc_integral"])
-    time_start_plot(diagnostics["time_start"])
-    time_diff_hist(diagnostics["time_start"], diagnostics["time_end"])
+    time_start_plot(np.array(diagnostics["time_start"]).flatten())
+    time_diff_hist(np.array(diagnostics["time_start"]).flatten(), np.array(diagnostics["time_end"]).flatten())
 
     if (not no_displays):
         all_event_displays(data.tp_data, run_id, sub_run_id)
-
-    tp_channel_histogram(data.tp_data)
 
 if __name__ == "__main__":
     main()

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -43,7 +43,7 @@ def num_tps_hist(num_tps):
 
 def time_start_plot(start_times, frag_index=-1):
     """
-    Plot in order the time_start member data for TAs.
+    Plot TA start times vs TA index.
     """
     first_time = start_times[0] * TICK_TO_SEC_SCALE
     total_ticks = start_times[-1] - start_times[0]
@@ -67,9 +67,10 @@ def algorithm_hist(algorithms):
     """
     Plot a histogram of the algorithm types for each TA.
     """
+    num_tas = len(algorithms)
     plt.figure(figsize=(12,8))
-    counts, _ , _ = plt.hist(np.array(algorithms).flatten(), bins=np.arange(-0.5, 8, 1), range=(0,7), align='mid', color='k')
-    print(f"Number of TAs: {np.sum(counts).astype(int)}")
+    plt.hist(np.array(algorithms).flatten(), bins=np.arange(-0.5, 8, 1), range=(0,7), align='mid', color='k', label=f"Number of TAs: {num_tas}")
+    print(f"Number of TAs: {num_tas}") # Enforcing output for useful metric
 
     plt.title("TA Algorithm Histogram")
     plt.xticks(ticks=range(0,8), labels=("Unknown",
@@ -80,6 +81,8 @@ def algorithm_hist(algorithms):
                                          "MichelElectron",
                                          "DBSCAN",
                                          "PlaneCoincidence"), rotation=60)
+
+    plt.legend()
 
     plt.tight_layout()
     plt.savefig("algorithm_histogram.svg")
@@ -162,7 +165,6 @@ def time_diff_hist(start_times, end_times):
 def event_display(peak_times, channels, idx):
     """
     Plot an individual event display.
-
     """
     plt.figure(figsize=(6,4))
 
@@ -181,6 +183,9 @@ def event_display(peak_times, channels, idx):
     plt.close()
 
 def parse():
+    """
+    Parses CLI input arguments.
+    """
     parser = argparse.ArgumentParser(description="Display diagnostic information for TAs for a given tpstream file.")
     parser.add_argument("filename", help="Absolute path to tpstream file to display.")
     parser.add_argument("--quiet", action="store_true", help="Stops the output of printed information. Default: False.")
@@ -210,16 +215,19 @@ def main():
                   }
 
     data = trgtools.TAData(filename, quiet)
-    if end_frag != 0:
+    if end_frag != 0: # Python doesn't like [n:0]
         frag_paths = data.get_ta_frag_paths()[start_frag:end_frag]
     elif end_frag == 0:
         frag_paths = data.get_ta_frag_paths()[start_frag:]
+
+    # Load data. May contain empty frags.
     for path in frag_paths:
         data.load_frag(path)
 
     run_id = data.run_id
     sub_run_id = data.sub_run_id
 
+    # Explicit plotting data
     for frag in data.ta_data:
         for ta in frag:
             diagnostics["num_tps"].append(ta["num_tps"])

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -1,0 +1,139 @@
+"""
+Display diagnostic information for TPs in a given
+tpstream file.
+"""
+
+import os
+import sys
+import argparse
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import trgtools
+
+TICK_TO_SEC_SCALE = 512e-9 # secs per tick
+
+def channel_tot(tp_data):
+    """
+    Plot the TP channel vs time over threshold scatter plot.
+    """
+    channels = []
+    tots = []
+    for frag_data in tp_data:
+        channel_data = frag_data['channel']
+        channels = channels + list(channel_data)
+        tot_data = frag_data['time_over_threshold']# * TICK_TO_SEC_SCALE
+        tots = tots + list(tot_data)
+
+    channels = np.array(channels)
+    tots = np.array(tots)
+    hot_channels = channels[np.where(tots >= 0.0075)]
+
+    plt.figure(figsize=(6,4), dpi=200)
+
+    plt.scatter(channels, tots, c='k', s=2, label='TP')
+
+    plt.title("TP Time Over Threshold vs Channel")
+    plt.xlabel("Channel")
+    plt.ylabel("Time Over Threshold (s)")
+    plt.legend()
+
+    plt.annotate(f"High ToT Channels: {np.unique(hot_channels)}", xy=(2250, 0.0175), va="center", ha="center", fontsize=8)
+
+    plt.tight_layout()
+    plt.savefig("channel_vs_tot.png")
+    plt.close()
+
+def tp_percent_histogram(tp_data):
+
+    channels = []
+    for frag_data in tp_data:
+        channel_data = frag_data['channel']
+        channels = channels + list(channel_data)
+    channels = np.array(channels)
+    counts, bins = np.histogram(channels, bins=np.arange(0.5, 3072.5, 1))
+
+    count_mask = np.ones(counts.shape, dtype=bool)
+    total_counts = np.sum(counts)
+
+    percent01 = np.sum(counts > 0.01*total_counts)
+    count_mask[np.where(counts > 0.01*total_counts)] = False
+
+    percent001 = np.sum(counts[count_mask] > 0.001*total_counts)
+    count_mask[np.where(counts[count_mask] > 0.001*total_counts)] = False
+
+    percent0001 = np.sum(counts[count_mask] > 0.0001*total_counts)
+    count_mask[np.where(counts[count_mask] > 0.0001*total_counts)] = False
+
+    remaining = np.sum(counts[count_mask])
+
+    plt.figure(figsize=(6,4))
+    plt.stairs([percent01, percent001, percent0001, remaining], [0,1,2,3,4], color='k', fill=True)
+
+    plt.xlim((0,4))
+    plt.xticks([0.5, 1.5, 2.5, 3.5], ['>1%', '>0.1%', '>0.01%', "Remainder"])
+
+    plt.title(f"Number of Channels Contributing % To Total Count {total_counts}")
+
+    plt.savefig("percent_total.svg")
+    plt.close()
+
+def tp_channel_histogram(tp_data):
+    """
+    Plot the TP channel histogram.
+    """
+    # tp_data is a list of length num frags
+    # Each element is an array with size num TPs
+    # => Iterate over every fragment -> get TP channel data -> append to list
+
+    channels = []
+    for frag_data in tp_data:
+        channel_data = frag_data['channel']
+        channels = channels + list(channel_data)
+
+    counts, bins = np.histogram(channels, bins=np.arange(0.5, 3072.5, 1))
+    total_counts = np.sum(counts)
+    print("High TP Count Channels:", np.where(counts >= 500))
+    print("Percentage Counts:", np.where(counts >= 0.01*total_counts))
+
+    plt.figure(figsize=(6,4))
+
+    plt.stairs(counts, bins, fill=True, color='k', label=f'TP Count: {total_counts}')
+
+    plt.title("TP Channel Histogram")
+    plt.xlabel("Channel")
+    plt.legend()
+
+    plt.ylim((0, 800))
+
+    plt.savefig("tp_channel_histogram.svg")
+    plt.close()
+
+def parse():
+    parser = argparse.ArgumentParser(description="Display diagnostic information for TAs for a given tpstream file.")
+    parser.add_argument("filename", help="Absolute path to tpstream file to display.")
+    parser.add_argument("--quiet", action="store_true", help="Stops the output of printed information. Default: False.")
+
+    return parser.parse_args()
+
+def main():
+    ## Process Arguments & Data
+    args = parse()
+    filename = args.filename
+    quiet = args.quiet
+
+    data = trgtools.TPData(filename, quiet)
+    num_frags = 10
+    frag_paths = data.get_tp_frag_paths()
+    for path in frag_paths[-1*num_frags:]:
+        print(path)
+        data.load_frag(path)
+
+    print("Length of tp_data:", len(data.tp_data))
+    tp_channel_histogram(data.tp_data)
+    channel_tot(data.tp_data)
+    tp_percent_histogram(data.tp_data)
+
+if __name__ == "__main__":
+    main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
-# Trigger , emulation and analysis tools
+# Trigger Emulation & Analysis Tools
 
 The `trgtools` repository contains a collection of tools and scripts to emulate, test and analyze the performance of trigger and trigger algorithms.
 
-- `process_tpstream`: Exaple of a simple pipeline to process TPStream files (slice by slide) and apply a trigger activity algorithm
+- `process_tpstream`: Example of a simple pipeline to process TPStream files (slice by slice) and apply a trigger activity algorithm.
+- `ta_dump.py`: Script that loads TPStream files containing trigger activities and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/ta-dump.md).

--- a/docs/ta-dump.md
+++ b/docs/ta-dump.md
@@ -4,10 +4,17 @@
 
 While running, this prints warnings for empty fragments that are skipped in the given HDF5 file. These outputs can be suppressed with `--quiet`.
 
+One can specify which fragments to _attempt_ to load from with the `--start-frag` option. This is `-10` by default in order to get the last 10 fragments for the given file. One can also specify which fragment to end on (not inclusive) with `--end-frag` option. This is `0` by default (for the previously mentioned reason).
+
+Event displays are processed by default. If there are many TAs that were loaded, then this may take a while to plot. The `--no-display` options skips event display plotting.
+
 ## Example
-```
+```bash
 python ta_dump.py file.hdf5
+python ta_dump.py file.hdf5 --help
 python ta_dump.py file.hdf5 --quiet
+python ta_dump.py file.hdf5 --start-frag 50 --end-frag 100 # Attempts 50 fragments
+python ta_dump.py file.hdf5 --no-display
 ```
 
 ## Run Numbers & File Naming

--- a/python/trgtools/TAData.py
+++ b/python/trgtools/TAData.py
@@ -47,8 +47,9 @@ class TAData:
     def __init__(self, filename, quiet=False):
         self._h5_file = HDF5RawDataFile(filename)
         self._set_ta_frag_paths(self._h5_file.get_all_fragment_dataset_paths())
-        self.ta_data = np.zeros((len(self._frag_paths),), dtype=self.ta_dt)
-        self.tp_data = []
+        self.ta_data = [] # Length = number of frags, elem = TAs in frag
+        self.tp_data = [] # Length = number of frags, elem = list of TPs in TAs
+        self._ta_size = trgdataformats.TriggerActivityOverlay().sizeof()
         self._quiet = quiet
         self._nonempty_frags_mask = np.ones((len(self._frag_paths),), dtype=bool)
         if "run" in filename:
@@ -85,8 +86,9 @@ class TAData:
         return self._frag_paths
 
     def load_frag(self, frag_path, index=None) -> (np.ndarray, np.ndarray):
-        ta = self._h5_file.get_frag(frag_path)
-        if ta.get_data_size() == 0:
+        frag = self._h5_file.get_frag(frag_path)
+        frag_data_size = frag.get_data_size()
+        if frag_data_size == 0:
             if not self._quiet:
                 print(self._FAIL_TEXT_COLOR + self._BOLD_TEXT + "WARNING: Empty fragment. Returning empty array." + self._END_TEXT_COLOR)
                 print(self._WARNING_TEXT_COLOR + self._BOLD_TEXT + f"INFO: Fragment Path: {frag_path}" + self._END_TEXT_COLOR)
@@ -96,43 +98,61 @@ class TAData:
         if index == None:
             index = self._frag_paths.index(frag_path)
 
-        ta_datum = trgdataformats.TriggerActivity(ta.get_data())
-        np_ta_datum = np.array([(
-                                ta_datum.data.adc_integral,
-                                ta_datum.data.adc_peak,
-                                np.uint8(ta_datum.data.algorithm),
-                                ta_datum.data.channel_end,
-                                ta_datum.data.channel_peak,
-                                ta_datum.data.channel_start,
-                                np.uint16(ta_datum.data.detid),
-                                ta_datum.n_inputs(),
-                                ta_datum.data.time_activity,
-                                ta_datum.data.time_end,
-                                ta_datum.data.time_peak,
-                                ta_datum.data.time_start,
-                                np.uint8(ta_datum.data.type))],
-                                dtype=self.ta_dt)
+        # Unknown number of TAs or TPs per TA.
+        frag_ta_data = []
+        frag_tp_data = []
 
-        num_tps = ta_datum.n_inputs()
-        np_tp_datum = np.zeros((num_tps,), dtype=self.tp_dt)
-        for idx, tp in enumerate(ta_datum):
-            np_tp_datum[idx] = np.array([(
-                                        tp.adc_integral,
-                                        tp.adc_peak,
-                                        tp.algorithm,
-                                        tp.channel,
-                                        tp.detid,
-                                        tp.flag,
-                                        tp.time_over_threshold,
-                                        tp.time_peak,
-                                        tp.time_start,
-                                        tp.type,
-                                        tp.version)],
-                                        dtype=self.tp_dt)
-        self.tp_data.append(np_tp_datum)
-        self.ta_data[index] = np_ta_datum
+        ta_idx = 0
+        byte_idx = 0 # Variable TA sizing, must do while loop
+        while (byte_idx < frag_data_size):
+            if (not self._quiet):
+                print(f"Fragment Index: {ta_idx}.")
+                print(f"Byte Index / Frag Size: {byte_idx} / {frag_data_size}")
+            ## Process TA data
+            ta_datum = trgdataformats.TriggerActivity(frag.get_data(byte_idx))
+            np_ta_datum = np.array([(
+                                    ta_datum.data.adc_integral,
+                                    ta_datum.data.adc_peak,
+                                    np.uint8(ta_datum.data.algorithm),
+                                    ta_datum.data.channel_end,
+                                    ta_datum.data.channel_peak,
+                                    ta_datum.data.channel_start,
+                                    np.uint16(ta_datum.data.detid),
+                                    ta_datum.n_inputs(),
+                                    ta_datum.data.time_activity,
+                                    ta_datum.data.time_end,
+                                    ta_datum.data.time_peak,
+                                    ta_datum.data.time_start,
+                                    np.uint8(ta_datum.data.type))],
+                                    dtype=self.ta_dt)
+            frag_ta_data.append(np_ta_datum)
+            byte_idx += ta_datum.sizeof()
+            if (not self._quiet):
+                print(f"Upcoming byte: {byte_idx}")
+            ta_idx += 1
 
-        return np_ta_datum, np_tp_datum
+            ## Process TP data
+            num_tps = ta_datum.n_inputs()
+            np_tp_data = np.zeros((num_tps,), dtype=self.tp_dt)
+            for tp_idx, tp in enumerate(ta_datum):
+                np_tp_data[tp_idx] = np.array([(
+                                            tp.adc_integral,
+                                            tp.adc_peak,
+                                            tp.algorithm,
+                                            tp.channel,
+                                            tp.detid,
+                                            tp.flag,
+                                            tp.time_over_threshold,
+                                            tp.time_peak,
+                                            tp.time_start,
+                                            tp.type,
+                                            tp.version)],
+                                            dtype=self.tp_dt)
+            frag_tp_data.append(np_tp_data) # Jagged
+        self.tp_data.append(frag_tp_data)
+        self.ta_data.append(frag_ta_data)
+
+        return frag_ta_data, frag_tp_data
 
     def _filter_frags(self) -> None:
         self.ta_data = self.ta_data[self._nonempty_frags_mask]

--- a/python/trgtools/TPData.py
+++ b/python/trgtools/TPData.py
@@ -1,0 +1,86 @@
+"""
+Class containing TP data and the ability to process data.
+"""
+
+import os
+
+import numpy as np
+
+from hdf5libs import HDF5RawDataFile
+import daqdataformats
+import trgdataformats
+
+class TPData:
+    _FAIL_TEXT_COLOR = '\033[91m'
+    _WARNING_TEXT_COLOR = '\033[93m'
+    _BOLD_TEXT = '\033[1m'
+    _END_TEXT_COLOR = '\033[0m'
+
+    tp_dt = np.dtype([
+                      ('adc_integral', np.uint32),
+                      ('adc_peak', np.uint32),
+                      ('algorithm', np.uint8),
+                      ('channel', np.int32),
+                      ('detid', np.uint16),
+                      ('flag', np.uint16),
+                      ('time_over_threshold', np.uint64),
+                      ('time_peak', np.uint64),
+                      ('time_start', np.uint64),
+                      ('type', np.uint8),
+                      ('version', np.uint16)
+                     ])
+
+    def __init__(self, filename, quiet=False):
+        self._h5_file = HDF5RawDataFile(filename)
+        self._set_tp_frag_paths(self._h5_file.get_all_fragment_dataset_paths())
+        self.tp_data = [] # Will have length == number of fragments
+        self._quiet = quiet
+
+    def _set_tp_frag_paths(self, frag_paths) -> None:
+        """
+        Only collect the fragment paths that are for TAs.
+        """
+        self._frag_paths = []
+        for frag_path in frag_paths:
+            if 'Trigger_Primitive' in frag_path:
+                self._frag_paths.append(frag_path)
+
+    def get_tp_frag_paths(self) -> list:
+        return self._frag_paths
+
+    def load_frag(self, frag_path) -> np.ndarray:
+        tp = self._h5_file.get_frag(frag_path)
+
+        data_size = tp.get_data_size()
+        tp_size = trgdataformats.TriggerPrimitive.sizeof()
+        num_tps = data_size // tp_size
+        print("Load frag, num_tps:", num_tps)
+
+        # TODO: Change name to frag_data since this object is all TPs in a frag
+        np_tp_datum = np.zeros((num_tps,), dtype=self.tp_dt)
+        for idx, tp_idx in enumerate(range(0, data_size, tp_size)):
+            tp_datum = trgdataformats.TriggerPrimitive(tp.get_data(tp_idx))
+
+            np_tp_datum[idx] = np.array([(
+                                        tp_datum.adc_integral,
+                                        tp_datum.adc_peak,
+                                        tp_datum.algorithm,
+                                        tp_datum.channel,
+                                        tp_datum.detid,
+                                        tp_datum.flag,
+                                        tp_datum.time_over_threshold,
+                                        tp_datum.time_peak,
+                                        tp_datum.time_start,
+                                        tp_datum.type,
+                                        tp_datum.version)],
+                                        dtype=self.tp_dt)
+        self.tp_data.append(np_tp_datum)
+
+        return np_tp_datum
+
+    def load_all_frags(self) -> None:
+        """
+        Load all of the fragments to the current object.
+        """
+        for idx, frag_path in enumerate(self._frag_paths):
+            _ = self.load_frag(frag_path) # Only care about the append to self.tp_data

--- a/python/trgtools/__init__.py
+++ b/python/trgtools/__init__.py
@@ -1,2 +1,3 @@
 from ._daq_trgtools_py import *
 from .TAData import TAData
+from .TPData import TPData


### PR DESCRIPTION
`TPData.py` previously only processed the first TA for every timeslice. These changes now allow processing every TA within a timeslice, but limits how many timeslices are loaded by default. This resulted in the additional flags `--start-frag` and `--end-frag` to control this.

Tests were done using an updated `ta_dump.py` and TPStream file produced from `process_tpstream`. The empty fragment problem from `process_tpstream` persists, but this is expected.