### PR TITLE
TA & TP Summary Statistics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.svg
 *.png
+*.txt
+*.pdf

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -136,7 +136,7 @@ def plot_summary_stats(ta_data, no_anomaly=False, quiet=False):
                 'time_start': "Time Start Summary",
                 'type': "Type (Sanity) Summary"
              }
-    anomaly_filename = 'anomaly_summary.txt'
+    anomaly_filename = 'ta_anomaly_summary.txt'
 
     if not no_anomaly:
         if not quiet:

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -73,7 +73,6 @@ def algorithm_hist(algorithms):
     num_tas = len(algorithms)
     plt.figure(figsize=(12,8))
     plt.hist(np.array(algorithms).flatten(), bins=np.arange(-0.5, 8, 1), range=(0,7), align='mid', color='k', label=f"Number of TAs: {num_tas}")
-    print(f"Number of TAs: {num_tas}") # Enforcing output for useful metric
 
     plt.title("TA Algorithm Histogram")
     plt.xticks(ticks=range(0,8), labels=("Unknown",
@@ -197,6 +196,7 @@ def plot_summary_stats(ta_data, no_anomaly=False, quiet=False):
 
     with PdfPages("ta_summary_stats.pdf") as pdf:
         for ta_key, title in titles.items():
+            # Extract only ta_key
             plot_data = []
             for frag_data in ta_data:
                 for ta in frag_data:
@@ -253,11 +253,12 @@ def all_event_displays(tp_data, run_id, sub_run_id):
 
                 plt.scatter(ta['time_peak'], ta['channel'], c='k', s=2)
 
+                # Auto limits were too wide; this narrows it.
                 max_time = np.max(ta['time_peak'])
                 min_time = np.min(ta['time_peak'])
                 time_diff = max_time - min_time
-
                 plt.xlim((min_time - 0.1*time_diff, max_time + 0.1*time_diff))
+
                 plt.title(f'Run {run_id}.{sub_run_id:04} Event Display: {fdx:03}.{tadx:03}')
                 plt.xlabel("Peak Time")
                 plt.ylabel("Channel")
@@ -376,6 +377,7 @@ def main():
 
     if (not quiet):
         print(f"Number of Fragments: {len(data.ta_data)}")
+    print(f"Number of TAs: {len(diagnostics['algorithm'])}") # Enforcing output for useful metric
 
     ## Plotting
     num_tps_hist(diagnostics["num_tps"])

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -25,6 +25,7 @@ def window_length_hist(window_lengths):
     plt.title("TA Time Window Length Histogram")
     plt.xlabel("Time Window Length (s)")
 
+    plt.tight_layout()
     plt.savefig("window_length_histogram.svg")
     plt.close()
 
@@ -38,6 +39,7 @@ def num_tps_hist(num_tps):
     plt.title("Number of TPs Histogram")
     plt.xlabel("Number of TPs")
 
+    plt.tight_layout()
     plt.savefig("num_tps_histogram.svg")
     plt.close()
 
@@ -60,6 +62,7 @@ def time_start_plot(start_times, frag_index=-1):
 
     plt.legend()
 
+    plt.tight_layout()
     plt.savefig("start_times.svg")
     plt.close()
 
@@ -100,6 +103,7 @@ def det_type_hist(det_types):
                                          "TPC",
                                          "PDS"), rotation=60)
 
+    plt.tight_layout()
     plt.savefig("det_types_histogram.svg")
     plt.close()
 
@@ -113,6 +117,7 @@ def adc_integral_hist(adc_integrals):
     plt.title("TA ADC Integral Histogram")
     plt.xlabel("ADC Integral")
 
+    plt.tight_layout()
     plt.savefig("adc_integral_histogram.svg")
     plt.close()
 
@@ -208,6 +213,7 @@ def plot_summary_stats(ta_data, no_anomaly=False, quiet=False):
 
             plt.title(title)
 
+            plt.tight_layout()
             pdf.savefig()
             plt.close()
 
@@ -256,6 +262,7 @@ def all_event_displays(tp_data, run_id, sub_run_id):
                 plt.xlabel("Peak Time")
                 plt.ylabel("Channel")
 
+                plt.tight_layout()
                 pdf.savefig()
                 plt.close()
 
@@ -279,6 +286,7 @@ def time_diff_hist(start_times, end_times):
     plt.xlabel("Seconds")
     plt.legend()
 
+    plt.tight_layout()
     plt.savefig("ta_timings_histogram.svg")
     plt.close()
 
@@ -299,6 +307,7 @@ def event_display(peak_times, channels, idx):
     plt.xlabel("Peak Time")
     plt.ylabel("Channel")
 
+    plt.tight_layout()
     plt.savefig(f"./event_display_{idx:03}.svg")
     plt.close()
 

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -136,6 +136,21 @@ def plot_summary_stats(ta_data, no_anomaly=False, quiet=False):
                 'time_start': "Time Start Summary",
                 'type': "Type (Sanity) Summary"
              }
+    labels = {
+                'adc_integral': "ADC Integral",
+                'adc_peak': "ADC Count",
+                'algorithm': "",
+                'channel_end': "Channel Number",
+                'channel_peak': "Channel Number",
+                'channel_start': "Channel Number",
+                'detid': "",
+                'num_tps': "TP Count",
+                'time_end': "Ticks",
+                'time_peak': "Ticks",
+                'time_start': "Ticks",
+                'type': ""
+             }
+
     anomaly_filename = 'ta_anomaly_summary.txt'
 
     if not no_anomaly:
@@ -161,6 +176,7 @@ def plot_summary_stats(ta_data, no_anomaly=False, quiet=False):
             plt.boxplot(plot_data, notch=True, vert=False, sym='+')
             plt.yticks([]) # Would just show '1'.
             ax.xaxis.grid(True)
+            plt.xlabel(labels[ta_key])
 
             plt.title(title)
 

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -116,6 +116,34 @@ def adc_integral_hist(adc_integrals):
     plt.savefig("adc_integral_histogram.svg")
     plt.close()
 
+def plot_time_window_summary(ta_data, tp_data, quiet=False):
+    """
+    Plot summary statistics on time windows.
+
+    This uses 2 definitions for time windows:
+        Direct Diff: max(tp.time_start) - ta.time_start,
+        Max Diff: max(tp.time_start + tp.time_over_threshold) - ta.time_start
+    """
+    direct_diff = []
+    max_diff = []
+
+    for ta_frag, tp_frag in zip(ta_data, tp_data):
+        for ta, tps in zip(ta_frag, tp_frag):
+            direct_diff += list(np.max(tps['time_start']) - ta['time_start'])
+            max_diff += list(np.max(tps['time_start'] + tps['time_over_threshold']) - ta['time_start'])
+    direct_diff = np.array(direct_diff)
+    max_diff = np.array(max_diff)
+
+    plt.figure(figsize=(6,4))
+    plt.boxplot((direct_diff, max_diff), notch=True, vert=False, sym='+', labels=["Direct Difference", "Maximum Difference"])
+
+    plt.title("TA Time Windows Summary")
+    plt.xlabel("Ticks")
+
+    plt.tight_layout()
+    plt.savefig("ta_time_windows_summary.svg")
+    plt.close()
+
 def plot_summary_stats(ta_data, no_anomaly=False, quiet=False):
     """
     Plot summary statistics on various TA member data.
@@ -348,6 +376,7 @@ def main():
     adc_integral_hist(diagnostics["adc_integral"])
     time_start_plot(np.array(diagnostics["time_start"]).flatten())
     time_diff_hist(np.array(diagnostics["time_start"]).flatten(), np.array(diagnostics["time_end"]).flatten())
+    plot_time_window_summary(data.ta_data, data.tp_data, quiet)
     plot_summary_stats(data.ta_data, no_anomaly, quiet)
 
     if (not no_displays):

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -191,7 +191,7 @@ def plot_summary_stats(ta_data, no_anomaly=False, quiet=False):
         import os
         from scipy import stats
         if os.path.isfile(anomaly_filename):
-            # Prepare a new anomaly_summary.txt
+            # Prepare a new ta_anomaly_summary.txt
             os.remove(anomaly_filename)
 
     with PdfPages("ta_summary_stats.pdf") as pdf:
@@ -322,7 +322,7 @@ def parse():
     parser.add_argument("--no-displays", action="store_true", help="Stops the processing of event displays.")
     parser.add_argument("--start-frag", type=int, help="Starting fragment index to process from. Takes negative indexing. Default: -10.", default=-10)
     parser.add_argument("--end-frag", type=int, help="Fragment index to stop processing (i.e. not inclusive). Takes negative indexing. Default: 0.", default=0)
-    parser.add_argument("--no-anomaly", action="store_true", help="Pass to not write 'anomaly_summary.txt. Default: False.")
+    parser.add_argument("--no-anomaly", action="store_true", help="Pass to not write 'ta_anomaly_summary.txt'. Default: False.")
 
     return parser.parse_args()
 

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -156,7 +156,7 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
         import os
         from scipy import stats # Only used when writing to file.
         if os.path.isfile(anomaly_filename):
-            # Prepare a new anomaly_summary.txt
+            # Prepare a new tp_anomaly_summary.txt
             os.remove(anomaly_filename)
 
     with PdfPages("tp_summary_stats.pdf") as pdf:
@@ -210,7 +210,7 @@ def parse():
     parser.add_argument("--quiet", action="store_true", help="Stops the output of printed information. Default: False.")
     parser.add_argument("--start-frag", type=int, help="Fragment to start loading from (inclusive); can take negative integers. Default: -10", default=-10)
     parser.add_argument("--end-frag", type=int, help="Fragment to stop loading at (exclusive); can take negative integers. Default: 0", default=0)
-    parser.add_argument("--no-anomaly", action="store_true", help="Pass to not write 'anomaly_summary.txt. Default: False.")
+    parser.add_argument("--no-anomaly", action="store_true", help="Pass to not write 'tp_anomaly_summary.txt'. Default: False.")
 
     return parser.parse_args()
 

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -77,6 +77,7 @@ def tp_percent_histogram(tp_data):
 
     plt.title(f"Number of Channels Contributing % To Total Count {total_counts}")
 
+    plt.tight_layout()
     plt.savefig("percent_total.svg")
     plt.close()
 
@@ -109,6 +110,7 @@ def tp_channel_histogram(tp_data, quiet=False):
 
     plt.ylim((0, 800))
 
+    plt.tight_layout()
     plt.savefig("tp_channel_histogram.svg")
     plt.close()
 
@@ -172,6 +174,7 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
 
             plt.title(title)
 
+            plt.tight_layout()
             pdf.savefig()
             plt.close()
 

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -9,6 +9,7 @@ import argparse
 
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
 
 import trgtools
 
@@ -111,12 +112,86 @@ def tp_channel_histogram(tp_data, quiet=False):
     plt.savefig("tp_channel_histogram.svg")
     plt.close()
 
+def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
+    """
+    Plot summary statistics on the various TP member data.
+    Displays as box plots on multiple pages of a PDF.
+    """
+    # 'Sanity' titles _should_ all be the same value.
+    titles = {
+                'adc_integral': "ADC Integral Summary",
+                'adc_peak': "ADC Peak Summary",
+                'algorithm': "Algorithm (Sanity) Summary",
+                'channel': "Channel Summary",
+                'detid': "Detector ID (Sanity) Summary",
+                'flag': "Flag (Sanity) Summary",
+                'time_over_threshold': "Time Over Threshold Summary",
+                'time_peak': "Time Peak Summary",
+                'time_start': "Time Start Summary",
+                'type': "Type (Sanity) Summary",
+                'version': "Version (Sanity) Summary"
+             }
+
+    anomaly_filename = 'anomaly_summary.txt'
+
+    if not no_anomaly:
+        if not quiet:
+            print(f"Writing descriptive statistics to {anomaly_filename}.")
+        import os
+        from scipy import stats # Only used when writing to file.
+        if os.path.isfile(anomaly_filename):
+            # Prepare a new anomaly_summary.txt
+            os.remove(anomaly_filename)
+
+    with PdfPages("tp_summary_stats.pdf") as pdf:
+        for tp_key, title in titles.items():
+            plot_data = []
+            for frag_data in tp_data:
+                plot_data = plot_data + list(frag_data[tp_key])
+            plot_data = np.array(plot_data)
+            plt.figure(figsize=(6,4))
+            ax = plt.gca()
+
+            plt.boxplot(plot_data, notch=True, vert=False, sym='+')
+            plt.yticks([])
+            ax.xaxis.grid(True)
+
+            plt.title(title)
+
+            pdf.savefig()
+            plt.close()
+
+            # Write anomalies to file.
+            if not no_anomaly:
+                if "Sanity" in title and np.all(plot_data == plot_data[0]):
+                    # Either passed check or all wrong in the same way.
+                    continue
+                summary = stats.describe(plot_data)
+                std = np.sqrt(summary.variance)
+                with open(anomaly_filename, 'a') as out:
+                    out.write(f"{title}\n")
+                    out.write(f"Reference Statistics:\n"            \
+                              f"\tTotal # TPs = {summary.nobs},\n"  \
+                              f"\tMean = {summary.mean:.2f},\n"     \
+                              f"\tStd = {std:.2f},\n"               \
+                              f"\tMin = {summary.minmax[0]},\n"     \
+                              f"\tMax = {summary.minmax[1]}.\n")
+                    std3_count = np.sum(plot_data > summary.mean + 3*std) \
+                               + np.sum(plot_data < summary.mean - 3*std)
+                    std2_count = np.sum(plot_data > summary.mean + 2*std) \
+                               + np.sum(plot_data < summary.mean - 2*std)
+                    out.write(f"Anomalies:\n"                           \
+                              f"\t# of >3 Sigma TPs = {std3_count},\n"  \
+                              f"\t# of >2 Sigma TPs = {std2_count}.\n")
+                    out.write("\n\n")
+
 def parse():
     parser = argparse.ArgumentParser(description="Display diagnostic information for TAs for a given tpstream file.")
     parser.add_argument("filename", help="Absolute path to tpstream file to display.")
     parser.add_argument("--quiet", action="store_true", help="Stops the output of printed information. Default: False.")
     parser.add_argument("--start-frag", type=int, help="Fragment to start loading from (inclusive); can take negative integers. Default: -10", default=-10)
     parser.add_argument("--end-frag", type=int, help="Fragment to stop loading at (exclusive); can take negative integers. Default: 0", default=0)
+    parser.add_argument("--no-anomaly", action="store_true", help="Pass to not write 'anomaly_summary.txt. Default: False.")
 
     return parser.parse_args()
 
@@ -127,6 +202,7 @@ def main():
     quiet = args.quiet
     start_frag = args.start_frag
     end_frag = args.end_frag
+    no_anomaly = args.no_anomaly
 
     data = trgtools.TPData(filename, quiet)
     if end_frag == 0: # Ex: [-10:0] is bad.
@@ -144,6 +220,7 @@ def main():
     tp_channel_histogram(data.tp_data, quiet)
     channel_tot(data.tp_data)
     tp_percent_histogram(data.tp_data)
+    plot_summary_stats(data.tp_data, no_anomaly, quiet)
 
 if __name__ == "__main__":
     main()

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -40,6 +40,7 @@ def channel_tot(tp_data):
     plt.ylabel("Time Over Threshold (Ticks)")
     plt.legend()
 
+    # Text of the channels with high counts
     #plt.annotate(f"High ToT Channels: {np.unique(hot_channels)}", xy=(750, 7250), va="center", ha="center", fontsize=8)
 
     plt.tight_layout()
@@ -160,6 +161,7 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
 
     with PdfPages("tp_summary_stats.pdf") as pdf:
         for tp_key, title in titles.items():
+            # Extract only ta_key
             plot_data = []
             for frag_data in tp_data:
                 plot_data = plot_data + list(frag_data[tp_key])

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -132,7 +132,7 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
                 'version': "Version (Sanity) Summary"
              }
 
-    anomaly_filename = 'anomaly_summary.txt'
+    anomaly_filename = 'tp_anomaly_summary.txt'
 
     if not no_anomaly:
         if not quiet:

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -131,6 +131,19 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
                 'type': "Type (Sanity) Summary",
                 'version': "Version (Sanity) Summary"
              }
+    labels = {
+                'adc_integral': "ADC Integral",
+                'adc_peak': "ADC Count",
+                'algorithm': "",
+                'channel': "Channel Number",
+                'detid': "",
+                'flag': "",
+                'time_over_threshold': "Ticks",
+                'time_peak': "Ticks",
+                'time_start': "Ticks",
+                'type': "",
+                'version': ""
+             }
 
     anomaly_filename = 'tp_anomaly_summary.txt'
 
@@ -155,6 +168,7 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
             plt.boxplot(plot_data, notch=True, vert=False, sym='+')
             plt.yticks([])
             ax.xaxis.grid(True)
+            plt.xlabel(labels[tp_key])
 
             plt.title(title)
 

--- a/docs/ta-dump.md
+++ b/docs/ta-dump.md
@@ -8,6 +8,8 @@ One can specify which fragments to _attempt_ to load from with the `--start-frag
 
 Event displays are processed by default. If there are many TAs that were loaded, then this may take a while to plot. The `--no-display` options skips event display plotting.
 
+A text file named `ta_anomaly_summary.txt` is generated that gives reference statistics for each TA data member and gives a count of data members that are at least 2 sigma and 3 sigma from the mean. One can use `--no-anomaly` to stop this file generation.
+
 ## Example
 ```bash
 python ta_dump.py file.hdf5
@@ -15,6 +17,7 @@ python ta_dump.py file.hdf5 --help
 python ta_dump.py file.hdf5 --quiet
 python ta_dump.py file.hdf5 --start-frag 50 --end-frag 100 # Attempts 50 fragments
 python ta_dump.py file.hdf5 --no-display
+python ta_dump.py file.hdf5 --no-anomaly
 ```
 
 ## Run Numbers & File Naming

--- a/docs/tp-dump.md
+++ b/docs/tp-dump.md
@@ -1,15 +1,18 @@
 # Trigger Primitive Dump Info
 
-`tp_dump.py` is a plotting script that shows TP diagnostic information, such as: TP channel histogram and channel vs time over threshold. Plots are saved as SVGs and PNGs.
+`tp_dump.py` is a plotting script that shows TP diagnostic information, such as: TP channel histogram and channel vs time over threshold. Plots are saved as SVGs, PDFs, and PNGs.
 
 While running, this script prints various loading information. These outputs can be suppressed with `--quiet`.
 
 One can specify which fragments to load from with the `--start-frag` option. This is -10 by default in order to get the last 10 fragments for the given file. One can also specify which fragment to end on (not inclusive) with `--end-frag` option. This is 0 by default (for the previously mentioned reason).
 
+A text file named `tp_anomaly_summary.txt` is generated that gives reference statistics for each TP data member and gives a count of data members that are at least 2 sigma and 3 sigma from the mean. One can use `--no-anomaly` to stop this file generation.
+
 ## Example
 ```bash
-python ta_dump.py file.hdf5 # Loads last 10 fragments by default.
-python ta_dump.py file.hdf5 --help
-python ta_dump.py file.hdf5 --quiet
-python ta_dump.py file.hdf5 --start-frag 50 --end-frag 100 # Loads 50 fragments.
+python tp_dump.py file.hdf5 # Loads last 10 fragments by default.
+python tp_dump.py file.hdf5 --help
+python tp_dump.py file.hdf5 --quiet
+python tp_dump.py file.hdf5 --start-frag 50 --end-frag 100 # Loads 50 fragments.
+python tp_dump.py file.hdf5 --no-anomaly
 ```


### PR DESCRIPTION
I've added box plots to both `ta_dump.py` and `tp_dump.py` in order to help summarize some of the statistics that are not easily visible in histograms. This is especially true for outliers. At the same time, a text file is generated that gives exact values for reference statistics (mean, median, standard deviation) and a count  of data members that are at least 2 sigma and 3 sigma away from the mean.