### PR TITLE
Added more TP histograms.

### DIFF
--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -82,19 +82,10 @@ def tp_percent_histogram(tp_data):
     plt.savefig("percent_total.svg")
     plt.close()
 
-def tp_channel_histogram(tp_data, quiet=False):
+def plot_channel_histogram(channels, quiet=False):
     """
     Plot the TP channel histogram.
     """
-    # tp_data is a list of length num frags
-    # Each element is an array with size num TPs
-    # => Iterate over every fragment -> get TP channel data -> append to list
-
-    channels = []
-    for frag_data in tp_data:
-        channel_data = frag_data['channel']
-        channels = channels + list(channel_data)
-
     counts, bins = np.histogram(channels, bins=np.arange(0.5, 3072.5, 1))
     total_counts = np.sum(counts)
     if (not quiet):
@@ -113,6 +104,166 @@ def tp_channel_histogram(tp_data, quiet=False):
 
     plt.tight_layout()
     plt.savefig("tp_channel_histogram.svg")
+    plt.close()
+
+def plot_version_histogram(versions, quiet=False):
+    """
+    Plot the TP versions histogram.
+
+    Generally, this will be one value.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(versions, color='k')
+
+    plt.title("TP Versions Histogram")
+    plt.xlabel("Versions")
+
+    plt.tight_layout()
+    plt.savefig("tp_versions_histogram.svg")
+    plt.close()
+
+def plot_type_histogram(types, quiet=False):
+    """
+    Plot the TP types histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(types, bins=np.arange(-0.5, 3, 1), range=(0,2), align='mid', color='k')
+
+    plt.title("TP Types Histogram")
+    plt.xlabel("Types")
+    plt.xticks([0,1,2], ["Unknown", "TPC", "PDS"]) # Taken from TriggerPrimitive.hpp
+
+    plt.tight_layout()
+    plt.savefig("tp_types_histogram.svg")
+    plt.close()
+
+def plot_time_start_histogram(times, quiet=False):
+    """
+    Plot the TP time starts histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(times, color='k')
+
+    plt.title("TP Time Starts Histogram")
+    plt.xlabel("Time Start (Ticks)")
+
+    plt.tight_layout()
+    plt.savefig("tp_time_start_histogram.svg")
+    plt.close()
+
+def plot_time_peak_histogram(times, quiet=False):
+    """
+    Plot the TP time peaks histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(times, color='k')
+
+    plt.title("TP Time Peaks Histogram")
+    plt.xlabel("Time Peak (Ticks)")
+
+    plt.tight_layout()
+    plt.savefig("tp_time_peak_histogram.svg")
+    plt.close()
+
+def plot_time_over_threshold_histogram(times, quiet=False):
+    """
+    Plot the TP time over threshold histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(times, color='k')
+
+    plt.title("TP Time Over Threshold Histogram")
+    plt.xlabel("Time Over Threshold (Ticks)")
+
+    plt.tight_layout()
+    plt.savefig("tp_time_over_threshold_histogram.svg")
+    plt.close()
+
+def plot_flag_histogram(flags, quiet=False):
+    """
+    Plot the TP flags histogram.
+
+    Generally, something notable. Likely difficult to read as a histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(flags, color='k')
+
+    plt.title("TP Flags Histogram")
+    plt.xlabel("Flags")
+
+    plt.tight_layout()
+    plt.savefig("tp_flags_histogram.svg")
+    plt.close()
+
+def plot_detid_histogram(det_ids, quiet=False):
+    """
+    Plot the TP detector IDs histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(det_ids, color='k')
+    # Uncertain what the values of the det_ids refer to, so they remain as numbers.
+
+    plt.title("TP Detector IDs Histogram")
+    plt.xlabel("Detector IDs")
+
+    plt.tight_layout()
+    plt.savefig("tp_det_ids_histogram.svg")
+    plt.close()
+
+def plot_algorithm_histogram(algorithms, quiet=False):
+    """
+    Plot the TP algoritm histogram.
+
+    Generally, this should be a single histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(algorithms, bins=np.arange(-0.5, 2, 1), range=(0,1), align='mid', color='k')
+
+    plt.title("TP Algorithms Histogram")
+    plt.xlabel("Algorithm")
+    plt.xticks([0,1], ["Unknown", "TPCDefault"])
+    # Values taken from TriggerPrimitive.hpp
+
+    plt.tight_layout()
+    plt.savefig("tp_algorithms_histogram.svg")
+    plt.close()
+
+def plot_adc_peak_histogram(adc_peaks, quiet=False):
+    """
+    Plot the TP peak histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(adc_peaks, color='k')
+
+    plt.title("TP ADC Peaks Histogram")
+    plt.xlabel("ADC Count")
+
+    plt.tight_layout()
+    plt.savefig("tp_adc_peaks_histogram.svg")
+    plt.close()
+
+def plot_adc_integral_histogram(adc_integrals, quiet=False):
+    """
+    Plot the TP ADC integral histogram.
+    """
+    plt.figure(figsize=(6,4))
+
+    plt.hist(adc_integrals, color='k')
+
+    plt.title("TP ADC Integrals Histogram")
+    plt.xlabel("ADC Integral")
+
+    plt.tight_layout()
+    plt.savefig("tp_adc_integral_histogram.svg")
     plt.close()
 
 def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
@@ -236,9 +387,45 @@ def main():
 
     if (not quiet):
         print("Length of tp_data:", len(data.tp_data))
-    tp_channel_histogram(data.tp_data, quiet)
+
+    ## Plots with more involved analysis
     channel_tot(data.tp_data)
     tp_percent_histogram(data.tp_data)
+
+    ## Basic Plots: Histograms & Box Plots
+    diagnostics = {
+                    'adc_integral': [],
+                    'adc_peak': [],
+                    'algorithm': [],
+                    'channel': [],
+                    'detid': [],
+                    'flag': [],
+                    'time_over_threshold': [],
+                    'time_peak': [],
+                    'time_start': [],
+                    'type': [],
+                    'version': [],
+                  }
+
+    # Each fragment can be different sizes, so must iterate over all fragments
+    # and stack dynamically.
+    for frag_data in data.tp_data:
+        for key in diagnostics:
+            diagnostics[key] += list(frag_data[key])
+
+    # For the moment, none of these functions make use of 'quiet'.
+    plot_adc_integral_histogram(diagnostics['adc_integral'], quiet)
+    plot_adc_peak_histogram(diagnostics['adc_peak'], quiet)
+    plot_algorithm_histogram(diagnostics['algorithm'], quiet)
+    plot_channel_histogram(diagnostics['channel'], quiet)
+    plot_detid_histogram(diagnostics['detid'], quiet)
+    plot_flag_histogram(diagnostics['flag'], quiet)
+    plot_time_over_threshold_histogram(diagnostics['time_over_threshold'], quiet)
+    plot_time_peak_histogram(diagnostics['time_peak'], quiet)
+    plot_time_start_histogram(diagnostics['time_start'], quiet)
+    plot_type_histogram(diagnostics['type'], quiet)
+    plot_version_histogram(diagnostics['version'], quiet)
+
     plot_summary_stats(data.tp_data, no_anomaly, quiet)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This added TP histograms for the remaining TP data members. This was tested against an arbitrary TPStream file and produced meaningful histograms for it.

Currently, the use of the `diagnostics` dictionary is problematic as it requires iterating through the processed TP data again. This will be solved in a future PR that restructures the processed TP data.