### PR TITLE
Removed Fragment Separation From TAData & TPData Classes

### DIFF
--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -25,7 +25,7 @@ def window_length_hist(window_lengths, seconds=False):
     time_unit = 'Ticks'
     if seconds:
         window_lengths = window_lengths * TICK_TO_SEC_SCALE
-        unit = 's'
+        time_unit = 's'
 
     plt.figure(figsize=(6,4))
     plt.hist(window_lengths, color='k')
@@ -270,7 +270,7 @@ def all_event_displays(tp_data, run_id, sub_run_id, seconds=False):
         for tadx, ta in enumerate(tp_data):
             if seconds:
                 ta = ta * TICK_TO_SEC_SCALE
-            fig = plt.figure(figsize=(6,4))
+            plt.figure(figsize=(6,4))
 
             plt.scatter(ta['time_peak'], ta['channel'], c='k', s=2)
 
@@ -362,6 +362,9 @@ def parse():
     return parser.parse_args()
 
 def main():
+    """
+    Drives the processing and plotting.
+    """
     ## Process Arguments & Data
     args = parse()
     filename = args.filename

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -10,10 +10,11 @@ import argparse
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
+from scipy import stats
 
 import trgtools
 
-TICK_TO_SEC_SCALE = 512e-9 # secs per tick
+TICK_TO_SEC_SCALE = 16e-9 # secs per tick
 
 def channel_tot(tp_data):
     """
@@ -249,10 +250,11 @@ def plot_adc_integral_histogram(adc_integrals, quiet=False):
     plt.savefig("tp_adc_integral_histogram.svg")
     plt.close()
 
-def write_summary_stats(data, summary, filename, title):
+def write_summary_stats(data, filename, title):
     """
     Writes the given summary statistics to 'filename'.
     """
+    summary = stats.describe(data)
     std = np.sqrt(summary.variance)
     with open(filename, 'a') as out:
         out.write(f"{title}\n")
@@ -309,8 +311,6 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
     if not no_anomaly:
         if not quiet:
             print(f"Writing descriptive statistics to {anomaly_filename}.")
-        import os
-        from scipy import stats # Only used when writing to file.
         if os.path.isfile(anomaly_filename):
             # Prepare a new tp_anomaly_summary.txt
             os.remove(anomaly_filename)
@@ -337,7 +337,7 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
                 if "Sanity" in title and np.all(tp_data[tp_key] == tp_data[tp_key][0]):
                     # Either passed check or all wrong in the same way.
                     continue
-                write_summary_stats(tp_data[tp_key], stats.describe(tp_data[tp_key]), anomaly_filename, title)
+                write_summary_stats(tp_data[tp_key], anomaly_filename, title)
 
 def parse():
     parser = argparse.ArgumentParser(description="Display diagnostic information for TAs for a given tpstream file.")

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -350,6 +350,9 @@ def parse():
     return parser.parse_args()
 
 def main():
+    """
+    Drives the processing and plotting.
+    """
     ## Process Arguments & Data
     args = parse()
     filename = args.filename

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -19,42 +19,25 @@ def channel_tot(tp_data):
     """
     Plot the TP channel vs time over threshold scatter plot.
     """
-    channels = []
-    tots = []
-    for frag_data in tp_data:
-        channel_data = frag_data['channel']
-        channels = channels + list(channel_data)
-        tot_data = frag_data['time_over_threshold']# * TICK_TO_SEC_SCALE
-        tots = tots + list(tot_data)
-
-    channels = np.array(channels)
-    tots = np.array(tots)
-    hot_channels = channels[np.where(tots >= 0.0075)]
-
     plt.figure(figsize=(6,4), dpi=200)
 
-    plt.scatter(channels, tots, c='k', s=2, label='TP')
+    plt.scatter(tp_data['channel'], tp_data['time_over_threshold'], c='k', s=2, label='TP')
 
     plt.title("TP Time Over Threshold vs Channel")
     plt.xlabel("Channel")
     plt.ylabel("Time Over Threshold (Ticks)")
     plt.legend()
 
-    # Text of the channels with high counts
-    #plt.annotate(f"High ToT Channels: {np.unique(hot_channels)}", xy=(750, 7250), va="center", ha="center", fontsize=8)
-
     plt.tight_layout()
-    plt.savefig("channel_vs_tot.png")
+    plt.savefig("tp_channel_vs_tot.png") # Many scatter points makes this a PNG
     plt.close()
 
 def tp_percent_histogram(tp_data):
-
-    channels = []
-    for frag_data in tp_data:
-        channel_data = frag_data['channel']
-        channels = channels + list(channel_data)
-    channels = np.array(channels)
-    counts, bins = np.histogram(channels, bins=np.arange(0.5, 3072.5, 1))
+    """
+    Plot the count of TPs that account for 1%, 0.1%, and 0.01%
+    of the total channel count.
+    """
+    counts, _ = np.histogram(tp_data['channel'], bins=np.arange(0.5, 3072.5, 1))
 
     count_mask = np.ones(counts.shape, dtype=bool)
     total_counts = np.sum(counts)
@@ -266,6 +249,28 @@ def plot_adc_integral_histogram(adc_integrals, quiet=False):
     plt.savefig("tp_adc_integral_histogram.svg")
     plt.close()
 
+def write_summary_stats(data, summary, filename, title):
+    """
+    Writes the given summary statistics to 'filename'.
+    """
+    std = np.sqrt(summary.variance)
+    with open(filename, 'a') as out:
+        out.write(f"{title}\n")
+        out.write(f"Reference Statistics:\n"            \
+                  f"\tTotal # TPs = {summary.nobs},\n"  \
+                  f"\tMean = {summary.mean:.2f},\n"     \
+                  f"\tStd = {std:.2f},\n"               \
+                  f"\tMin = {summary.minmax[0]},\n"     \
+                  f"\tMax = {summary.minmax[1]}.\n")
+        std3_count = np.sum(data > summary.mean + 3*std) \
+                   + np.sum(data < summary.mean - 3*std)
+        std2_count = np.sum(data > summary.mean + 2*std) \
+                   + np.sum(data < summary.mean - 2*std)
+        out.write(f"Anomalies:\n"                           \
+                  f"\t# of >3 Sigma TPs = {std3_count},\n"  \
+                  f"\t# of >2 Sigma TPs = {std2_count}.\n")
+        out.write("\n\n")
+
 def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
     """
     Plot summary statistics on the various TP member data.
@@ -312,15 +317,11 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
 
     with PdfPages("tp_summary_stats.pdf") as pdf:
         for tp_key, title in titles.items():
-            # Extract only ta_key
-            plot_data = []
-            for frag_data in tp_data:
-                plot_data = plot_data + list(frag_data[tp_key])
-            plot_data = np.array(plot_data)
             plt.figure(figsize=(6,4))
             ax = plt.gca()
 
-            plt.boxplot(plot_data, notch=True, vert=False, sym='+')
+            # Only plot the 'tp_key'
+            plt.boxplot(tp_data[tp_key], notch=True, vert=False, sym='+')
             plt.yticks([])
             ax.xaxis.grid(True)
             plt.xlabel(labels[tp_key])
@@ -333,27 +334,10 @@ def plot_summary_stats(tp_data, no_anomaly=False, quiet=False):
 
             # Write anomalies to file.
             if not no_anomaly:
-                if "Sanity" in title and np.all(plot_data == plot_data[0]):
+                if "Sanity" in title and np.all(tp_data[tp_key] == tp_data[tp_key][0]):
                     # Either passed check or all wrong in the same way.
                     continue
-                summary = stats.describe(plot_data)
-                std = np.sqrt(summary.variance)
-                with open(anomaly_filename, 'a') as out:
-                    out.write(f"{title}\n")
-                    out.write(f"Reference Statistics:\n"            \
-                              f"\tTotal # TPs = {summary.nobs},\n"  \
-                              f"\tMean = {summary.mean:.2f},\n"     \
-                              f"\tStd = {std:.2f},\n"               \
-                              f"\tMin = {summary.minmax[0]},\n"     \
-                              f"\tMax = {summary.minmax[1]}.\n")
-                    std3_count = np.sum(plot_data > summary.mean + 3*std) \
-                               + np.sum(plot_data < summary.mean - 3*std)
-                    std2_count = np.sum(plot_data > summary.mean + 2*std) \
-                               + np.sum(plot_data < summary.mean - 2*std)
-                    out.write(f"Anomalies:\n"                           \
-                              f"\t# of >3 Sigma TPs = {std3_count},\n"  \
-                              f"\t# of >2 Sigma TPs = {std2_count}.\n")
-                    out.write("\n\n")
+                write_summary_stats(tp_data[tp_key], stats.describe(tp_data[tp_key]), anomaly_filename, title)
 
 def parse():
     parser = argparse.ArgumentParser(description="Display diagnostic information for TAs for a given tpstream file.")
@@ -386,45 +370,25 @@ def main():
         data.load_frag(path)
 
     if (not quiet):
-        print("Length of tp_data:", len(data.tp_data))
+        print("Size of tp_data:", data.tp_data.shape)
 
     ## Plots with more involved analysis
     channel_tot(data.tp_data)
     tp_percent_histogram(data.tp_data)
 
     ## Basic Plots: Histograms & Box Plots
-    diagnostics = {
-                    'adc_integral': [],
-                    'adc_peak': [],
-                    'algorithm': [],
-                    'channel': [],
-                    'detid': [],
-                    'flag': [],
-                    'time_over_threshold': [],
-                    'time_peak': [],
-                    'time_start': [],
-                    'type': [],
-                    'version': [],
-                  }
-
-    # Each fragment can be different sizes, so must iterate over all fragments
-    # and stack dynamically.
-    for frag_data in data.tp_data:
-        for key in diagnostics:
-            diagnostics[key] += list(frag_data[key])
-
     # For the moment, none of these functions make use of 'quiet'.
-    plot_adc_integral_histogram(diagnostics['adc_integral'], quiet)
-    plot_adc_peak_histogram(diagnostics['adc_peak'], quiet)
-    plot_algorithm_histogram(diagnostics['algorithm'], quiet)
-    plot_channel_histogram(diagnostics['channel'], quiet)
-    plot_detid_histogram(diagnostics['detid'], quiet)
-    plot_flag_histogram(diagnostics['flag'], quiet)
-    plot_time_over_threshold_histogram(diagnostics['time_over_threshold'], quiet)
-    plot_time_peak_histogram(diagnostics['time_peak'], quiet)
-    plot_time_start_histogram(diagnostics['time_start'], quiet)
-    plot_type_histogram(diagnostics['type'], quiet)
-    plot_version_histogram(diagnostics['version'], quiet)
+    plot_adc_integral_histogram(data.tp_data['adc_integral'], quiet)
+    plot_adc_peak_histogram(data.tp_data['adc_peak'], quiet)
+    plot_algorithm_histogram(data.tp_data['algorithm'], quiet)
+    plot_channel_histogram(data.tp_data['channel'], quiet)
+    plot_detid_histogram(data.tp_data['detid'], quiet)
+    plot_flag_histogram(data.tp_data['flag'], quiet)
+    plot_time_over_threshold_histogram(data.tp_data['time_over_threshold'], quiet)
+    plot_time_peak_histogram(data.tp_data['time_peak'], quiet)
+    plot_time_start_histogram(data.tp_data['time_start'], quiet)
+    plot_type_histogram(data.tp_data['type'], quiet)
+    plot_version_histogram(data.tp_data['version'], quiet)
 
     plot_summary_stats(data.tp_data, no_anomaly, quiet)
 

--- a/python/trgtools/TAData.py
+++ b/python/trgtools/TAData.py
@@ -67,12 +67,13 @@ class TAData:
         self._set_ta_frag_paths(self._h5_file.get_all_fragment_dataset_paths())
         self._quiet = quiet
 
-        self.ta_data = [] # Length = number of frags, elem = TAs in frag
-        self.tp_data = [] # Length = number of frags, elem = list of TPs in TAs
+        self.ta_data = np.array([], dtype=self.ta_dt).reshape(0,1) # Will concatenate new TAs
+        self.tp_data = [] # tp_data[i] will be a np.ndarray of TPs from the i-th TA
         self._ta_size = trgdataformats.TriggerActivityOverlay().sizeof()
 
         # Masking frags that are found as empty.
         self._nonempty_frags_mask = np.ones((len(self._frag_paths),), dtype=bool)
+        self._num_empty = 0
 
         if "run" in filename: # Waiting on hdf5libs PR to use get_int_attribute
             tmp_name = filename.split("run")[1]
@@ -107,27 +108,24 @@ class TAData:
     def get_ta_frag_paths(self) -> list:
         return self._frag_paths
 
-    def load_frag(self, frag_path, index=None) -> (list, list):
+    def load_frag(self, frag_path, index=None) -> None:
         """
         Load a fragment from a given fragment path.
-
-        Returns two lists: TA data and TP data.
+        Saves the results to self.ta_data and self.tp_data.
+        Returns nothing.
         """
         frag = self._h5_file.get_frag(frag_path)
         frag_data_size = frag.get_data_size()
         if frag_data_size == 0:
+            self._num_empty += 1
             if not self._quiet:
                 print(self._FAIL_TEXT_COLOR + self._BOLD_TEXT + "WARNING: Empty fragment. Returning empty array." + self._END_TEXT_COLOR)
                 print(self._WARNING_TEXT_COLOR + self._BOLD_TEXT + f"INFO: Fragment Path: {frag_path}" + self._END_TEXT_COLOR)
             if index != None:
                 self._nonempty_frags_mask[index] = False
-            return list(), list()
+            return
         if index == None:
             index = self._frag_paths.index(frag_path)
-
-        # Unknown number of TAs or TPs per TA.
-        frag_ta_data = []
-        frag_tp_data = []
 
         ta_idx = 0 # Only used to output.
         byte_idx = 0 # Variable TA sizing, must do while loop.
@@ -152,15 +150,14 @@ class TAData:
                                     ta_datum.data.time_peak,
                                     ta_datum.data.time_start,
                                     np.uint8(ta_datum.data.type))],
-                                    dtype=self.ta_dt)
-            frag_ta_data.append(np_ta_datum)
+                                    dtype=self.ta_dt).reshape(1,1)
+            self.ta_data = np.vstack((self.ta_data, np_ta_datum))
             byte_idx += ta_datum.sizeof()
             if (not self._quiet):
                 print(f"Upcoming byte: {byte_idx}")
 
             ## Process TP data
-            num_tps = ta_datum.n_inputs()
-            np_tp_data = np.zeros((num_tps,), dtype=self.tp_dt)
+            np_tp_data = np.zeros((np_ta_datum['num_tps'],), dtype=self.tp_dt)
             for tp_idx, tp in enumerate(ta_datum):
                 np_tp_data[tp_idx] = np.array([(
                                             tp.adc_integral,
@@ -175,11 +172,9 @@ class TAData:
                                             tp.type,
                                             tp.version)],
                                             dtype=self.tp_dt)
-            frag_tp_data.append(np_tp_data) # Jagged array
-        self.tp_data.append(frag_tp_data)
-        self.ta_data.append(frag_ta_data)
+            self.tp_data.append(np_tp_data) # Jagged array
 
-        return frag_ta_data, frag_tp_data
+        return
 
     def load_all_frags(self) -> None:
         """
@@ -188,10 +183,7 @@ class TAData:
         Returns nothing. Data is accessible from obj.ta_data
         and obj.tp_data.
         """
-        miscount = 0
         for idx, frag_path in enumerate(self._frag_paths):
-            ta_datum, _ = self.load_frag(frag_path, idx)
-            if len(ta_datum) == 0:
-                miscount += 1
-        if miscount != 0 and not self._quiet:
-            print(self._FAIL_TEXT_COLOR + self._BOLD_TEXT + f"WARNING: Skipped {miscount} frags." + self._END_TEXT_COLOR)
+            self.load_frag(frag_path, idx)
+        if self._num_empty != 0 and not self._quiet:
+            print(self._FAIL_TEXT_COLOR + self._BOLD_TEXT + f"WARNING: Skipped {self._num_empty} frags." + self._END_TEXT_COLOR)

--- a/python/trgtools/TAData.py
+++ b/python/trgtools/TAData.py
@@ -157,7 +157,7 @@ class TAData:
                 print(f"Upcoming byte: {byte_idx}")
 
             ## Process TP data
-            np_tp_data = np.zeros((np_ta_datum['num_tps'],), dtype=self.tp_dt)
+            np_tp_data = np.zeros(np_ta_datum['num_tps'][0], dtype=self.tp_dt)
             for tp_idx, tp in enumerate(ta_datum):
                 np_tp_data[tp_idx] = np.array([(
                                             tp.adc_integral,

--- a/python/trgtools/TAData.py
+++ b/python/trgtools/TAData.py
@@ -67,7 +67,7 @@ class TAData:
         self._set_ta_frag_paths(self._h5_file.get_all_fragment_dataset_paths())
         self._quiet = quiet
 
-        self.ta_data = np.array([], dtype=self.ta_dt).reshape(0,1) # Will concatenate new TAs
+        self.ta_data = np.array([], dtype=self.ta_dt) # Will concatenate new TAs
         self.tp_data = [] # tp_data[i] will be a np.ndarray of TPs from the i-th TA
         self._ta_size = trgdataformats.TriggerActivityOverlay().sizeof()
 
@@ -150,14 +150,14 @@ class TAData:
                                     ta_datum.data.time_peak,
                                     ta_datum.data.time_start,
                                     np.uint8(ta_datum.data.type))],
-                                    dtype=self.ta_dt).reshape(1,1)
-            self.ta_data = np.vstack((self.ta_data, np_ta_datum))
+                                    dtype=self.ta_dt)
+            self.ta_data = np.hstack((self.ta_data, np_ta_datum))
             byte_idx += ta_datum.sizeof()
             if (not self._quiet):
                 print(f"Upcoming byte: {byte_idx}")
 
             ## Process TP data
-            np_tp_data = np.zeros(np_ta_datum['num_tps'][0], dtype=self.tp_dt)
+            np_tp_data = np.zeros(np_ta_datum['num_tps'], dtype=self.tp_dt)
             for tp_idx, tp in enumerate(ta_datum):
                 np_tp_data[tp_idx] = np.array([(
                                             tp.adc_integral,

--- a/python/trgtools/TPData.py
+++ b/python/trgtools/TPData.py
@@ -45,7 +45,7 @@ class TPData:
         """
         self._h5_file = HDF5RawDataFile(filename)
         self._set_tp_frag_paths(self._h5_file.get_all_fragment_dataset_paths())
-        self.tp_data = [] # Will have length == number of fragments
+        self.tp_data = np.array([], dtype=self.tp_dt) # Will concatenate TPs
         self._quiet = quiet
 
     def _set_tp_frag_paths(self, frag_paths) -> None:
@@ -92,7 +92,7 @@ class TPData:
                                         tp_datum.type,
                                         tp_datum.version)],
                                         dtype=self.tp_dt)
-        self.tp_data.append(np_tp_data)
+        self.tp_data = np.hstack((self.tp_data, np_tp_data))
 
         return np_tp_data
 


### PR DESCRIPTION
The `TAData` and `TPData` classes used a similar format that preserved the order of data fragments. In use, this appears as `TAData().ta_data[fragment_index][ta_index]` and `TPData().tp_data[fragment_index][tp_index]`. Since the number of TAs and TPs in a fragment is irregular, this resulted in jagged arrays and prevented use of NumPy vectorization.

This PR removes the need of `fragment_index` while preserving the TA/TP time order, so the new use is `TPData().ta_data[ta_index]` and `TPData().tp_data[tp_index]`. This is a significant speed increase and usability increase. The rest of this PR makes the required format changes to `ta_dump.py` and `tp_dump.py`, and this was tested by visually inspecting the results of these plotting scripts (found no difference).

In the future, it may be worth writing a new data class `FragmentData` which contains relevant fragment header data, such as Source ID.