### PR TITLE
Remove C Python Binding Import

### DIFF
--- a/python/trgtools/__init__.py
+++ b/python/trgtools/__init__.py
@@ -1,3 +1,2 @@
-from ._daq_trgtools_py import *
 from .TAData import TAData
 from .TPData import TPData


### PR DESCRIPTION
This (hopefully) closes #14. Since building this repository with `dbt-build` does not produce this error, I'm not certain how to test this (or if this truly is the solution to that problem).

The reason I believe this solves the bug is due to the backward compatibility `ImportError` for Python 3.9 not working on 3.10. An `ImportError` like [this is cited](https://discuss.python.org/t/importerror-python-version-mismatch/18168) to being caused by C bindings, so I want to test that removing the C binding should solve this.

Building with `dbt-build` produces no errors, so this should remain working as it is.