### PR TITLE
Using HDF5 File Attributes To Separate Outputs

### DIFF
--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -399,7 +399,9 @@ def main():
         plot_iter += 1
         plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
     print(f"Saving outputs to ./{plot_dir}/")
-    if not overwrite:  # Can only create new dirs.
+    # If overwriting and it does exist, don't need to make it.
+    # So take the inverse to mkdir.
+    if not (overwrite and os.path.isdir(plot_dir)):
         os.mkdir(plot_dir)
     os.chdir(plot_dir)
 

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -358,6 +358,7 @@ def parse():
     parser.add_argument("--end-frag", type=int, help="Fragment index to stop processing (i.e. not inclusive). Takes negative indexing. Default: 0.", default=0)
     parser.add_argument("--no-anomaly", action="store_true", help="Pass to not write 'ta_anomaly_summary.txt'. Default: False.")
     parser.add_argument("--seconds", action="store_true", help="Pass to use seconds instead of time ticks. Default: False.")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite old outputs. Default: False.")
 
     return parser.parse_args()
 
@@ -374,6 +375,7 @@ def main():
     end_frag = args.end_frag
     no_anomaly = args.no_anomaly
     seconds = args.seconds
+    overwrite = args.overwrite
 
     data = trgtools.TAData(filename, quiet)
 
@@ -393,11 +395,12 @@ def main():
     # Try to find an empty plotting directory
     plot_iter = 0
     plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
-    while os.path.isdir(plot_dir):
+    while not overwrite and os.path.isdir(plot_dir):
         plot_iter += 1
         plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
-    print(f"Saving figures to {plot_dir}")
-    os.mkdir(plot_dir)
+    print(f"Saving outputs to ./{plot_dir}/")
+    if not overwrite:  # Can only create new dirs.
+        os.mkdir(plot_dir)
     os.chdir(plot_dir)
 
     print(f"Number of TAs: {data.ta_data.shape[0]}") # Enforcing output for useful metric

--- a/apps/ta_dump.py
+++ b/apps/ta_dump.py
@@ -258,7 +258,7 @@ def plot_summary_stats(ta_data, no_anomaly=False, quiet=False):
                 write_summary_stats(ta_data[ta_key], anomaly_filename, title)
 
 
-def all_event_displays(tp_data, run_id, sub_run_id, seconds=False):
+def all_event_displays(tp_data, run_id, file_index, seconds=False):
     """
     Plot all event_displays as pages in a PDF.
 
@@ -266,7 +266,7 @@ def all_event_displays(tp_data, run_id, sub_run_id, seconds=False):
     """
     time_unit = 's' if seconds else 'Ticks'
 
-    with PdfPages(f"event_displays_{run_id}.{sub_run_id:04}.pdf") as pdf:
+    with PdfPages(f"event_displays_{run_id}.{file_index:04}.pdf") as pdf:
         for tadx, ta in enumerate(tp_data):
             if seconds:
                 ta = ta * TICK_TO_SEC_SCALE
@@ -280,7 +280,7 @@ def all_event_displays(tp_data, run_id, sub_run_id, seconds=False):
             time_diff = max_time - min_time
             plt.xlim((min_time - 0.1*time_diff, max_time + 0.1*time_diff))
 
-            plt.title(f'Run {run_id}.{sub_run_id:04} Event Display: {tadx:03}')
+            plt.title(f'Run {run_id}.{file_index:04} Event Display: {tadx:03}')
             plt.xlabel(f"Peak Time ({time_unit})")
             plt.ylabel("Channel")
 
@@ -390,8 +390,15 @@ def main():
         for path in frag_paths:
             data.load_frag(path)
 
-    run_id = data.run_id
-    sub_run_id = data.sub_run_id
+    # Try to find an empty plotting directory
+    plot_iter = 0
+    plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
+    while os.path.isdir(plot_dir):
+        plot_iter += 1
+        plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
+    print(f"Saving figures to {plot_dir}")
+    os.mkdir(plot_dir)
+    os.chdir(plot_dir)
 
     print(f"Number of TAs: {data.ta_data.shape[0]}") # Enforcing output for useful metric
 
@@ -407,7 +414,7 @@ def main():
     plot_summary_stats(data.ta_data, no_anomaly, quiet)
 
     if (not no_displays):
-        all_event_displays(data.tp_data, run_id, sub_run_id, seconds)
+        all_event_displays(data.tp_data, data.run_id, data.file_index, seconds)
 
 if __name__ == "__main__":
     main()

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -381,7 +381,9 @@ def main():
         plot_iter += 1
         plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
     print(f"Saving outputs to ./{plot_dir}/")
-    if not overwrite:  # Can only create new dirs.
+    # If overwriting and it does exist, don't need to make it.
+    # So take the inverse to mkdir.
+    if not (overwrite and os.path.isdir(plot_dir)):
         os.mkdir(plot_dir)
     os.chdir(plot_dir)
 

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -372,6 +372,16 @@ def main():
             print("Fragment Path:", path)
         data.load_frag(path)
 
+    # Try to find an empty plotting directory
+    plot_iter = 0
+    plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
+    while os.path.isdir(plot_dir):
+        plot_iter += 1
+        plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
+    print(f"Saving figures to {plot_dir}")
+    os.mkdir(plot_dir)
+    os.chdir(plot_dir)
+
     if (not quiet):
         print("Size of tp_data:", data.tp_data.shape)
 

--- a/apps/tp_dump.py
+++ b/apps/tp_dump.py
@@ -346,6 +346,7 @@ def parse():
     parser.add_argument("--start-frag", type=int, help="Fragment to start loading from (inclusive); can take negative integers. Default: -10", default=-10)
     parser.add_argument("--end-frag", type=int, help="Fragment to stop loading at (exclusive); can take negative integers. Default: 0", default=0)
     parser.add_argument("--no-anomaly", action="store_true", help="Pass to not write 'tp_anomaly_summary.txt'. Default: False.")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite old outputs. Default: False.")
 
     return parser.parse_args()
 
@@ -360,6 +361,7 @@ def main():
     start_frag = args.start_frag
     end_frag = args.end_frag
     no_anomaly = args.no_anomaly
+    overwrite = args.overwrite
 
     data = trgtools.TPData(filename, quiet)
     if end_frag == 0: # Ex: [-10:0] is bad.
@@ -375,11 +377,12 @@ def main():
     # Try to find an empty plotting directory
     plot_iter = 0
     plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
-    while os.path.isdir(plot_dir):
+    while not overwrite and os.path.isdir(plot_dir):
         plot_iter += 1
         plot_dir = f"{data.run_id}-{data.file_index}_figures_{plot_iter:04}"
-    print(f"Saving figures to {plot_dir}")
-    os.mkdir(plot_dir)
+    print(f"Saving outputs to ./{plot_dir}/")
+    if not overwrite:  # Can only create new dirs.
+        os.mkdir(plot_dir)
     os.chdir(plot_dir)
 
     if (not quiet):

--- a/python/trgtools/TAData.py
+++ b/python/trgtools/TAData.py
@@ -74,26 +74,9 @@ class TAData:
         # Masking frags that are found as empty.
         self._nonempty_frags_mask = np.ones((len(self._frag_paths),), dtype=bool)
 
-        if "run" in filename: # Waiting on hdf5libs PR to use get_int_attribute
-            tmp_name = filename.split("run")[1]
-            try:
-                self.run_id = int(tmp_name.split("_")[0])
-            except:
-                if not self._quiet:
-                    print(self._WARNING_TEXT_COLOR + "WARNING: Couldn't find Run ID in file name. Using run id 0." + self._END_TEXT_COLOR)
-                self.run_id = 0
-            try:
-                self.sub_run_id = int(tmp_name.split("_")[1])
-            except:
-                if not self._quiet:
-                    print(self._WARNING_TEXT_COLOR + "WARNING: Couldn't find SubRun ID in file name. Using SubRun ID 1000." + self._END_TEXT_COLOR)
-                self.sub_run_id = 1000
-        else:
-            if not self._quiet:
-                print(self._WARNING_TEXT_COLOR + "WARNING: Couldn't find Run ID in file name. Using run id 0." + self._END_TEXT_COLOR)
-                print(self._WARNING_TEXT_COLOR + "WARNING: Couldn't find SubRun ID in file name. Using SubRun ID 1000." + self._END_TEXT_COLOR)
-            self.run_id = 0
-            self.sub_run_id = 1000
+        # File identification attributes
+        self.run_id = self._h5_file.get_int_attribute('run_number')
+        self.file_index = self._h5_file.get_int_attribute('file_index')
 
     def _set_ta_frag_paths(self, frag_paths) -> None:
         """

--- a/python/trgtools/TPData.py
+++ b/python/trgtools/TPData.py
@@ -48,6 +48,10 @@ class TPData:
         self.tp_data = [] # Will have length == number of fragments
         self._quiet = quiet
 
+        # File identification attributes
+        self.run_id = self._h5_file.get_int_attribute('run_number')
+        self.file_index = self._h5_file.get_int_attribute('file_index')
+
     def _set_tp_frag_paths(self, frag_paths) -> None:
         """
         Only collect the fragment paths that are for TAs.


### PR DESCRIPTION
Currently, output plots and txts are dumped into the current working directory and contained little information about the original HDF5 file it was run on.

[PR 68](https://github.com/DUNE-DAQ/hdf5libs/pull/68) in `hdf5libs` now allows for accurate accessing of the HDF5 run number and file index. This PR implements those accessing methods to create an output directory with the style `<run number>-<file index>_figure_<count>` where `<count>` gets incremented for already existing directories. A new option `--overwrite` can be used to overwrite `<run number>-<file index>_figures_0000` instead of incrementing to a new directory name.

This was tested by running Python interactively and accessing the new data members in `TAData` and `TPData` as well as running over `tp_dump.py` and `ta_dump.py` to check that directory creation and overwriting is extensive. This included `--overwrite` with and without directories to overwrite and without `--overwrite` with and without directories to increment through.

Since this requires a change outside of this repository, early nightly versions may be missing this and would not work.