### PR TITLE
TC Data Class & Plots

### DIFF
--- a/apps/tc_dump.py
+++ b/apps/tc_dump.py
@@ -350,9 +350,9 @@ def main():
         data.load_all_frags()  # Has extra debug/warning info
     else:  # Only load some.
         if end_frag != 0:  # Python doesn't like [n:0]
-            frag_paths = data.get_ta_frag_paths()[start_frag:end_frag]
+            frag_paths = data.get_tc_frag_paths()[start_frag:end_frag]
         elif end_frag == 0:
-            frag_paths = data.get_ta_frag_paths()[start_frag:]
+            frag_paths = data.get_tc_frag_paths()[start_frag:]
 
         # Does not count empty frags.
         for path in frag_paths:

--- a/apps/tc_dump.py
+++ b/apps/tc_dump.py
@@ -511,6 +511,7 @@ def main():
             time_start = time_start * TICK_TO_SEC_SCALE
 
         yerr = np.array([time_candidate - time_start, time_end - time_candidate]).astype(np.int64)
+        time_unit = "Seconds" if seconds else "Ticks"
         time_spans_dict = {
                 'title': "TC Relative Time Spans",
                 'xlabel': "TC",
@@ -520,7 +521,7 @@ def main():
                     'capsize': 4,
                     'color': 'k',
                     'ecolor': 'r',
-                    'label': f"Avg Ticks / TC: {(time_candidate[-1] - time_candidate[0]) / len(time_candidate):.2f}",
+                    'label': f"Avg {time_unit} / TC: {(time_candidate[-1] - time_candidate[0]) / len(time_candidate):.2f}",
                     'marker': '.',
                     'markersize': 0.01
                 }

--- a/apps/tc_dump.py
+++ b/apps/tc_dump.py
@@ -3,15 +3,15 @@ Display diagnostic information for TCs for a given
 tpstream file.
 """
 
-import os
-import argparse
+import trgtools
 
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 from scipy import stats
 
-import trgtools
+import os
+import argparse
 
 
 TICK_TO_SEC_SCALE = 16e-9  # s per tick

--- a/apps/tc_dump.py
+++ b/apps/tc_dump.py
@@ -62,6 +62,11 @@ def plot_pdf_histogram(
         ax2.hist(data, bins=bins, color='#EE442F', label='Log', alpha=0.6)
         ax2.set_yscale('log')
 
+        # Setting the plot order
+        ax.set_zorder(2)
+        ax.patch.set_visible(False)
+        ax2.set_zorder(1)
+
         handles, labels = ax.get_legend_handles_labels()
         handles2, labels2 = ax2.get_legend_handles_labels()
         handles = handles + handles2
@@ -440,7 +445,7 @@ def main():
             },
             'version': {
                 'title': "Version",
-                'xlabel': "Version"
+                'xlabel': "Versions"
             }
     }
     with PdfPages(f"tc_data_member_histograms_{run_id}-{file_index:04}.pdf") as pdf:

--- a/apps/tc_dump.py
+++ b/apps/tc_dump.py
@@ -144,7 +144,7 @@ def plot_pdf_errorbar(
     Returns:
         Nothing. Mutates :pdf: with the new plot.
     """
-    plt.figure(figsize=plot_details_dict.get('figsize', (6,4)))
+    plt.figure(figsize=plot_details_dict.get('figsize', (6, 4)))
 
     errorbar_style = plot_details_dict.get('errorbar_style', {})
     plt.errorbar(x_data, y_data, **errorbar_style)

--- a/apps/tc_dump.py
+++ b/apps/tc_dump.py
@@ -4,7 +4,6 @@ tpstream file.
 """
 
 import os
-import sys
 import argparse
 
 import numpy as np
@@ -82,6 +81,80 @@ def plot_pdf_histogram(
     pdf.savefig()
     plt.close()
 
+    return None
+
+
+def plot_pdf_scatter(
+        x_data: np.ndarray,
+        y_data: np.ndarray,
+        plot_details_dict: dict,
+        pdf: PdfPages) -> None:
+    """
+    Plot a scatter plot for the given x and y data to a PdfPages object.
+
+    Parameters:
+        x_data (np.ndarray): Array to use as x values.
+        y_data (np.ndarray): Array to use as y values.
+        plot_details_dict (dict): Dictionary with keys such as 'title', 'xlabel', etc.
+        pdf (PdfPages): The PdfPages object that this plot will be appended to.
+
+    Returns:
+        Nothing. Mutates :pdf: with the new plot.
+    """
+    # May or may not have a preferred style on the scatter, e.g., marker, color, size.
+    scatter_style = plot_details_dict.get('scatter_style', {})
+
+    plt.figure(figsize=(6, 4))
+    plt.scatter(x_data, y_data, **scatter_style)
+
+    # Asserts that the following need to be in the plotting details.
+    # Who wants unlabeled plots?
+    plt.title(plot_details_dict['title'])
+    plt.xlabel(plot_details_dict['xlabel'])
+    plt.ylabel(plot_details_dict['ylabel'])
+
+    plt.tight_layout()
+    pdf.savefig()
+    plt.close()
+
+    return None
+
+
+def plot_pdf_errorbar(
+        x_data: np.ndarray,
+        y_data: np.ndarray,
+        plot_details_dict: dict,
+        pdf: PdfPages) -> None:
+    """
+    Plot a scatter plot for the given x and y data to a PdfPages object.
+    Error bars are handled by :plot_details_dict: since they are a style
+    choice.
+
+    Parameters:
+        x_data (np.ndarray): Array to use as x values.
+        y_data (np.ndarray): Array to use as y values.
+        plot_details_dict (dict): Dictionary with keys such as 'title', 'xlabel', etc.
+        pdf (PdfPages): The PdfPages object that this plot will be appended to.
+
+    Returns:
+        Nothing. Mutates :pdf: with the new plot.
+    """
+    plt.figure(figsize=plot_details_dict.get('figsize', (6,4)))
+
+    errorbar_style = plot_details_dict.get('errorbar_style', {})
+    plt.errorbar(x_data, y_data, **errorbar_style)
+
+    # Asserts that the following need to be in the plotting details.
+    # Who wants unlabeled plots?
+    plt.title(plot_details_dict['title'])
+    plt.xlabel(plot_details_dict['xlabel'])
+    plt.ylabel(plot_details_dict['ylabel'])
+
+    plt.legend()
+
+    plt.tight_layout()
+    pdf.savefig()
+    plt.close()
     return None
 
 
@@ -215,7 +288,8 @@ def parse():
     parser.add_argument(
         "--end-frag",
         type=int,
-        help="Fragment index to stop processing (i.e. not inclusive). Takes negative indexing. Default: 0.",
+        help="Fragment index to stop processing (i.e. not inclusive)."
+             + "Takes negative indexing. Default: 0.",
         default=0
     )
     parser.add_argument(
@@ -380,15 +454,75 @@ def main():
                 min_time = np.min(time)  # Prefer making the relative time change.
                 plot_pdf_histogram(time - min_time, plot_dict[tc_key], pdf, linear, log)
                 if not no_anomaly:
-                    write_summary_stats(time - min_time, anomaly_filename, plot_dict[tc_key]['title'])
+                    write_summary_stats(time - min_time, anomaly_filename,
+                                        plot_dict[tc_key]['title'])
                 continue
 
             plot_pdf_histogram(data.tc_data[tc_key], plot_dict[tc_key], pdf, linear, log)
             if not no_anomaly:
-                write_summary_stats(data.tc_data[tc_key], anomaly_filename, plot_dict[tc_key]['title'])
+                write_summary_stats(data.tc_data[tc_key], anomaly_filename,
+                                    plot_dict[tc_key]['title'])
 
         # "Analysis" plots
+        # ==== Time Delta Comparisons =====
         plot_pdf_time_delta_histograms(data.tc_data, data.ta_data, pdf, time_label)
+
+        tc_adc_integrals = np.array([np.sum(tas['adc_integral']) for tas in data.ta_data])
+        adc_integrals_dict = {
+                'title': "TC ADC Integrals",
+                'xlabel': "ADC Integral"
+        }
+        plot_pdf_histogram(tc_adc_integrals, adc_integrals_dict, pdf, linear, log)
+        # =================================
+
+        # ==== ADC Integral vs Number of TAs ====
+        integral_vs_num_tas_dict = {
+                'title': "TC ADC Integral vs Number of TAs",
+                'xlabel': "Number of TAs",
+                'ylabel': "TC ADC Integral",
+                'scatter_style': {
+                    'alpha': 0.6,
+                    'c': 'k',
+                    's': 2
+                }
+        }
+        plot_pdf_scatter(data.tc_data['num_tas'], tc_adc_integrals, integral_vs_num_tas_dict, pdf)
+        # =======================================
+
+        # ==== Time Spans Per TC ====
+        time_candidate = data.tc_data['time_candidate']
+        time_end = data.tc_data['time_end']
+        time_start = data.tc_data['time_start']
+        tc_min_time = np.min((time_candidate, time_end, time_start))
+
+        time_candidate -= tc_min_time
+        time_end -= tc_min_time
+        time_start -= tc_min_time
+
+        if seconds:
+            tc_min_time = tc_min_time * TICK_TO_SEC_SCALE
+            time_candidate = time_candidate * TICK_TO_SEC_SCALE
+            time_end = time_end * TICK_TO_SEC_SCALE
+            time_start = time_start * TICK_TO_SEC_SCALE
+
+        yerr = np.array([time_candidate - time_start, time_end - time_candidate]).astype(np.int64)
+        time_spans_dict = {
+                'title': "TC Relative Time Spans",
+                'xlabel': "TC",
+                'ylabel': time_label,
+                'errorbar_style': {
+                    'yerr': yerr,
+                    'capsize': 4,
+                    'color': 'k',
+                    'ecolor': 'r',
+                    'label': f"Avg Ticks / TC: {(time_candidate[-1] - time_candidate[0]) / len(time_candidate):.2f}",
+                    'marker': '.',
+                    'markersize': 0.01
+                }
+        }
+        tc_count = np.arange(len(time_candidate))
+        plot_pdf_errorbar(tc_count, time_candidate, time_spans_dict, pdf)
+        # ===========================
 
     return None
 

--- a/apps/tc_dump.py
+++ b/apps/tc_dump.py
@@ -1,0 +1,387 @@
+"""
+Display diagnostic information for TCs for a given
+tpstream file.
+"""
+
+import os
+import sys
+import argparse
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+from scipy import stats
+
+import trgtools
+
+
+TICK_TO_SEC_SCALE = 16e-9  # s per tick
+
+
+def plot_pdf_histogram(
+        data: np.ndarray,
+        plot_details_dict: dict,
+        pdf: PdfPages,
+        linear: bool = True,
+        log: bool = True) -> None:
+    """
+    Plot a histogram for the given data to a PdfPages object.
+
+    Parameters:
+        data (np.ndarray): Array to plot a histogram of.
+        plot_details_dict (dict): Dictionary with keys such as 'title', 'xlabel', etc.
+        pdf (PdfPages): The PdfPages object that this plot will be appended to.
+        linear (bool): Option to use linear y-scale.
+        log (bool): Option to use logarithmic y-scale.
+
+    Returns:
+        Nothing. Mutates :pdf: with the new plot.
+    """
+    plt.figure(figsize=(6, 4))
+    ax = plt.gca()
+    bins = 100
+
+    # Custom xticks are for specific typing. Expect to see much
+    # smaller plots, so only do linear and use less bins.
+    if 'xticks' in plot_details_dict:
+        linear = True
+        log = False
+        plt.xticks(
+                plot_details_dict['xticks']['ticks'],
+                plot_details_dict['xticks']['labels'],
+                rotation=plot_details_dict['xticks']['rotation'],
+                ha=plot_details_dict['xticks']['ha']
+        )
+    if 'bins' in plot_details_dict:
+        bins = plot_details_dict['bins']
+
+    if linear and log:
+        ax.hist(data, bins=bins, color='#63ACBE', label='Linear', alpha=0.6)
+        ax.set_yscale('linear')
+
+        ax2 = ax.twinx()
+        ax2.hist(data, bins=bins, color='#EE442F', label='Log', alpha=0.6)
+        ax2.set_yscale('log')
+
+        handles, labels = ax.get_legend_handles_labels()
+        handles2, labels2 = ax2.get_legend_handles_labels()
+        handles = handles + handles2
+        labels = labels + labels2
+        plt.legend(handles=handles, labels=labels)
+    else:
+        plt.hist(data, bins=bins, color='k')
+        if log:  # Default to linear, so only change on log
+            plt.yscale('log')
+
+    plt.title(plot_details_dict['title'] + " Histogram")
+    ax.set_xlabel(plot_details_dict['xlabel'])
+    if 'xlim' in plot_details_dict:
+        plt.xlim(plot_details_dict['xlim'])
+
+    plt.tight_layout()
+    pdf.savefig()
+    plt.close()
+
+    return None
+
+
+def plot_pdf_time_delta_histograms(
+        tc_data: np.ndarray,
+        ta_data: list[np.ndarray],
+        pdf: PdfPages,
+        time_label: str) -> None:
+    """
+    Plot the different time delta histograms to a PdfPages.
+
+    Parameters:
+        tc_data (np.ndarray): Array of TC data members.
+        ta_data (list[np.ndarray]): List of TAs per TC. ta_data[i] holds TA data for the i-th TC.
+        pdf (PdfPages): PdfPages object to append plot to.
+        time_label (str): Time label to plot with (ticks vs seconds).
+
+    Returns:
+        Nothing. Mutates :pdf: with the new plot.
+    """
+    direct_diff = tc_data['time_end'] - tc_data['time_start']
+    last_ta_start_diff = []
+    last_ta_end_diff = []
+    pure_ta_diff = []
+    for idx, ta in enumerate(ta_data):
+        last_ta_start_diff.append(np.max(ta['time_start']) - tc_data[idx]['time_start'])
+        last_ta_end_diff.append(np.max(ta['time_end']) - tc_data[idx]['time_start'])
+        pure_ta_diff.append(np.max(ta['time_end']) - np.min(ta['time_start']))
+
+    last_ta_start_diff = np.array(last_ta_start_diff)
+    last_ta_end_diff = np.array(last_ta_end_diff)
+    pure_ta_diff = np.array(pure_ta_diff)
+
+    # Seconds case.
+    if "Ticks" not in time_label:
+        direct_diff = direct_diff * TICK_TO_SEC_SCALE
+        last_ta_start_diff = last_ta_start_diff * TICK_TO_SEC_SCALE
+        last_ta_end_diff = last_ta_end_diff * TICK_TO_SEC_SCALE
+        pure_ta_diff = pure_ta_diff * TICK_TO_SEC_SCALE
+
+    bins = 40
+
+    plt.figure(figsize=(6, 4))
+
+    plt.hist(
+            (direct_diff, last_ta_start_diff, last_ta_end_diff, pure_ta_diff),
+            bins=bins,
+            label=(
+                "TC(End) - TC(Start)",
+                "Last TA(Start) - TC(Start)",
+                "Last TA(End) - TC(Start)",
+                "Last TA(End) - First TA(Start)"
+            ),
+            color=(
+                "#CA0020",
+                "#F4A582",
+                "#92C5DE",
+                "#0571B0"
+            ),
+            alpha=0.6
+    )
+
+    plt.title("Time Difference Histograms")
+    plt.xlabel(time_label)
+    plt.legend(framealpha=0.4)
+
+    plt.tight_layout()
+    pdf.savefig()
+
+    plt.close()
+    return None
+
+
+def write_summary_stats(data: np.ndarray, filename: str, title: str) -> None:
+    """
+    Writes the given summary statistics to 'filename'.
+
+    Parameters:
+        data (np.ndarray): Data set to calculate statistics on.
+        filename (str): File to write to.
+        title (str): Title of this data set.
+    Returns:
+        Nothing. Appends to the given filename.
+    """
+    # Algorithm, Det ID, etc. are not expected to vary.
+    # Check first that they don't vary, and move on if so.
+    if np.all(data == data[0]):
+        print(f"{title} data member is the same for all TCs. Skipping summary statistics.")
+        return
+
+    summary = stats.describe(data)
+    std = np.sqrt(summary.variance)
+    with open(filename, 'a') as out:
+        out.write(f"{title}\n")
+        out.write(f"Reference Statistics:\n"
+                  f"\tTotal # TCs = {summary.nobs},\n"
+                  f"\tMean = {summary.mean:.2f},\n"
+                  f"\tStd = {std:.2f},\n"
+                  f"\tMin = {summary.minmax[0]},\n"
+                  f"\tMax = {summary.minmax[1]}.\n")
+        std3_count = np.sum(data > summary.mean + 3*std) + np.sum(data < summary.mean - 3*std)
+        std2_count = np.sum(data > summary.mean + 2*std) + np.sum(data < summary.mean - 2*std)
+        out.write(f"Anomalies:\n"
+                  f"\t# of >3 Sigma TCs = {std3_count},\n"
+                  f"\t# of >2 Sigma TCs = {std2_count}.\n")
+        out.write("\n\n")
+
+
+def parse():
+    """
+    Parses CLI input arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Display diagnostic information for TCs for a given tpstream file."
+    )
+    parser.add_argument(
+        "filename",
+        help="Absolute path to tpstream file to display."
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Stops the output of printed information. Default: False."
+    )
+    parser.add_argument(
+        "--start-frag",
+        type=int,
+        help="Starting fragment index to process from. Takes negative indexing. Default: -10.",
+        default=-10
+    )
+    parser.add_argument(
+        "--end-frag",
+        type=int,
+        help="Fragment index to stop processing (i.e. not inclusive). Takes negative indexing. Default: 0.",
+        default=0
+    )
+    parser.add_argument(
+        "--no-anomaly",
+        action="store_true",
+        help="Pass to not write 'ta_anomaly_summary.txt'. Default: False."
+    )
+    parser.add_argument(
+        "--seconds",
+        action="store_true",
+        help="Pass to use seconds instead of time ticks. Default: False."
+    )
+    parser.add_argument(
+        "--linear",
+        action="store_true",
+        help="Pass to use linear histogram scaling. Default: plots both linear and log."
+    )
+    parser.add_argument(
+        "--log",
+        action="store_true",
+        help="Pass to use logarithmic histogram scaling. Default: plots both linear and log."
+    )
+
+    return parser.parse_args()
+
+
+def main():
+    """
+    Drives the processing and plotting.
+    """
+    # Process Arguments & Data
+    args = parse()
+    filename = args.filename
+    quiet = args.quiet
+    start_frag = args.start_frag
+    end_frag = args.end_frag
+    no_anomaly = args.no_anomaly
+    seconds = args.seconds
+    linear = args.linear
+    log = args.log
+
+    # User didn't pass either flag, so default to both being true.
+    if (not linear) and (not log):
+        linear = True
+        log = True
+
+    data = trgtools.TCData(filename, quiet)
+    run_id = data.run_id
+    file_index = data.file_index
+
+    # Load all case.
+    if start_frag == 0 and end_frag == -1:
+        data.load_all_frags()  # Has extra debug/warning info
+    else:  # Only load some.
+        if end_frag != 0:  # Python doesn't like [n:0]
+            frag_paths = data.get_ta_frag_paths()[start_frag:end_frag]
+        elif end_frag == 0:
+            frag_paths = data.get_ta_frag_paths()[start_frag:]
+
+        # Does not count empty frags.
+        for path in frag_paths:
+            data.load_frag(path)
+
+    print(f"Number of TCs: {data.tc_data.shape[0]}")  # Enforcing output for useful metric
+
+    # Plotting
+
+    anomaly_filename = "tc_anomalies.txt"
+    time_label = "Time (s)" if seconds else "Time (Ticks)"
+
+    # Dictionary containing unique title, xlabel, and xticks (only some)
+    plot_dict = {
+            'algorithm': {
+                'bins': np.arange(-0.5, 9.5, 1),
+                'title': "Algorithm",
+                'xlabel': 'Algorithm Type',
+                'xlim': (-1, 9),
+                'xticks': {
+                    'ticks': range(0, 9),
+                    'labels': (
+                        "Unknown",
+                        "Supernova",
+                        "HSIEventToTriggerCandidate",
+                        "Prescale",
+                        "ADCSimpleWindow",
+                        "HorizontalMuon",
+                        "MichelElectron",
+                        "PlaneCoincidence",
+                        "Custom"
+                    ),
+                    'rotation': 60,
+                    'ha': 'right'  # Horizontal alignment
+                }
+            },
+            'detid': {
+                'title': "Detector ID",
+                'xlabel': "Detector IDs"
+            },
+            'num_tas': {
+                'title': "Number of TAs per TC",
+                'xlabel': "Number of TAs"
+            },
+            'time_candidate': {
+                'title': "Relative Time Candidate",
+                'xlabel': time_label
+            },
+            'time_end': {
+                'title': "Relative Time End",
+                'xlabel': time_label
+            },
+            'time_peak': {
+                'title': "Relative Time Peak",
+                'xlabel': time_label
+            },
+            'time_start': {
+                'title': "Relative Time Start",
+                'xlabel': time_label
+            },
+            'type': {
+                'bins': np.arange(-0.5, 10.5, 1),
+                'title': "Type",
+                'xlabel': "Type",
+                'xlim': (-1, 10),
+                'xticks': {
+                    'ticks': range(0, 10),  # Ticks to change
+                    'labels': (
+                        'Unknown',
+                        'Timing',
+                        'TPCLowE',
+                        'Supernova',
+                        'Random',
+                        'Prescale',
+                        'ADCSimpleWindow',
+                        'HorizontalMuon',
+                        'MichelElectron',
+                        'PlaneCoincidence'
+                        ),
+                    'rotation': 60,
+                    'ha': 'right'  # Horizontal alignment
+                    }
+            },
+            'version': {
+                'title': "Version",
+                'xlabel': "Version"
+            }
+    }
+    with PdfPages("tc_data_member_histograms.pdf") as pdf:
+
+        # Generic plots
+        for tc_key in data.tc_data.dtype.names:
+            if not no_anomaly:
+                write_summary_stats(data.tc_data[tc_key], anomaly_filename, plot_dict[tc_key]['title'])
+            if 'time' in tc_key:
+                time = data.tc_data[tc_key]
+                if seconds:
+                    time = time * TICK_TO_SEC_SCALE
+                min_time = np.min(time)  # Prefer making the relative time change.
+                plot_pdf_histogram(time - min_time, plot_dict[tc_key], pdf, linear, log)
+                continue
+            plot_pdf_histogram(data.tc_data[tc_key], plot_dict[tc_key], pdf, linear, log)
+
+        # "Analysis" plots
+        plot_pdf_time_delta_histograms(data.tc_data, data.ta_data, pdf, time_label)
+
+    return None
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,5 +3,6 @@
 The `trgtools` repository contains a collection of tools and scripts to emulate, test and analyze the performance of trigger and trigger algorithms.
 
 - `process_tpstream`: Example of a simple pipeline to process TPStream files (slice by slice) and apply a trigger activity algorithm.
-- `ta_dump.py`: Script that loads TPStream files containing trigger activities and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/ta-dump.md).
-- `tp_dump.py`:  Script that loads TPStream files containing trigger primitives and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/tp-dump.md).
+- `ta_dump.py`: Script that loads HDF5 files containing trigger activities and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/ta-dump.md).
+- `tc_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/tc-dump.md).
+- `tp_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/tp-dump.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,6 @@
 The `trgtools` repository contains a collection of tools and scripts to emulate, test and analyze the performance of trigger and trigger algorithms.
 
 - `process_tpstream`: Example of a simple pipeline to process TPStream files (slice by slice) and apply a trigger activity algorithm.
-- `ta_dump.py`: Script that loads HDF5 files containing trigger activities and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/ta-dump.md).
-- `tc_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/tc-dump.md).
-- `tp_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](https://github.com/DUNE-DAQ/trgtools/blob/develop/docs/tp-dump.md).
+- `ta_dump.py`: Script that loads HDF5 files containing trigger activities and plots various diagnostic information. [Documentation](ta-dump.md).
+- `tc_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](tc-dump.md).
+- `tp_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](tp-dump.md).

--- a/docs/tc-dump.md
+++ b/docs/tc-dump.md
@@ -1,0 +1,22 @@
+# Trigger Candidate Dump Info
+`tc_dump.py` is a plotting script that shows TC diagnostic information. This includes histograms of all the available data members and ADC integral (sum of all contained TA ADC integrals) and a few light analysis plots:time difference histogram (various start and end time definitions), ADC integral vs number of TAs scatter plot, time spans per TC plot (including a calculation for the number of ticks per TC). These plots are written to a single PDF with multiple pages.
+
+There are two plotting options `--linear` and `--log` that set the y-scale for the plots. By default, plots use both scales with linear on the left y-axis and log on the right y-axis. There is an additional plotting option `--seconds` to produce time plots using seconds instead of ticks.
+
+While running, this prints warnings and general information about loading and plotting. These outputs can be suppressed with `--quiet`.
+
+One can specify which fragments to _attempt_ to load from with the `--start-frag` option. This is `-10` by default in order to get the last 10 fragments for the given file. One can also specify which fragment to end on (not inclusive) with `--end-frag` option. This is `0` by default (for the previously mentioned reason).
+
+A text file named `tc_anomalies_<run_number>-<file_index>.txt` is generated that gives reference statistics for each TA data member and gives a count of data members that are at least 2 sigma and 3 sigma from the mean. One can use `--no-anomaly` to stop this file generation.
+
+## Example
+```bash
+python tc_dump.py file.hdf5
+python tc_dump.py file.hdf5 --help
+python tc_dump.py file.hdf5 --quiet
+python tc_dump.py file.hdf5 --start-frag 50 --end-frag 100 # Attempts 50 fragments
+python tc_dump.py file.hdf5 --no-anomaly
+python tc_dump.py file.hdf5 --log
+python tc_dump.py file.hdf5 --linear
+python tc_dump.py file.hdf5 --seconds
+```

--- a/python/trgtools/TCData.py
+++ b/python/trgtools/TCData.py
@@ -2,13 +2,13 @@
 TriggerCandidate reader class to read and store data
 from an HDF5 file.
 """
-import os
+import daqdataformats  # Not directly used, but necessary to interpret formats.
+from hdf5libs import HDF5RawDataFile
+import trgdataformats
 
 import numpy as np
 
-import daqdataformats
-from hdf5libs import HDF5RawDataFile
-import trgdataformats
+import os
 
 
 class TCData():

--- a/python/trgtools/TCData.py
+++ b/python/trgtools/TCData.py
@@ -150,7 +150,7 @@ class TCData():
 
             byte_idx += tc_datum.sizeof()
             if not self._quiet:
-                print(f"Upcoming byte: {byte_idx}.")
+                print(f"Upcoming byte index: {byte_idx}.")
 
             # Process TA data
             np_ta_data = np.zeros(np_tc_datum['num_tas'], dtype=self.ta_dt)

--- a/python/trgtools/TCData.py
+++ b/python/trgtools/TCData.py
@@ -1,0 +1,185 @@
+"""
+TriggerCandidate reader class to read and store data
+from an HDF5 file.
+"""
+import os
+
+import numpy as np
+
+import daqdataformats
+from hdf5libs import HDF5RawDataFile
+import trgdataformats
+
+class TCData():
+    """
+    Class that reads a given HDF5 TPStream file and stores
+    the TC fragments within
+
+    Loading fragments populates obj.tc_data and obj.ta_data.
+    Numpy dtypes of ta_data and tp_data are available as
+    obj.ta_dt and obj.tp_dt.
+
+    Gives warnings and information when trying to load
+    empty fragments. Can be quieted with quiet=True on
+    init.
+    """
+
+    # TC data type
+    tc_dt = np.dtype([
+        ('algorithm', np.uint8),
+        ('detid', np.uint16),
+        ('num_tas', np.uint64),  # Greedy
+        ('time_candidate', np.uint64),
+        ('time_end', np.uint64),
+        ('time_start', np.uint64),
+        ('type', np.uint8),
+        ('version', np.uint16),
+    ])
+
+    # TA data type
+    ta_dt = np.dtype([
+        ('adc_integral', np.uint64),
+        ('adc_peak', np.uint64),
+        ('algorithm', np.uint8),
+        ('channel_end', np.int32),
+        ('channel_peak', np.int32),
+        ('channel_start', np.int32),
+        ('detid', np.uint16),
+        ('time_activity', np.uint64),
+        ('time_end', np.uint64),
+        ('time_peak', np.uint64),
+        ('time_start', np.uint64),
+        ('type', np.uint8),
+        ('version', np.uint16)
+    ])
+
+    tc_data = np.array([], dtype=tc_dt)  # Will concatenate new TCs
+    ta_data = []  # ta_data[i] will be a np.ndarray of TAs from the i-th TC
+    _tc_size = trgdataformats.TriggerCandidateOverlay().sizeof()
+    _num_empty = 0
+
+    def __init__(self, filename: str, quiet: bool = False) -> None:
+        """
+        Loads a given HDF5 file.
+
+        Parameters:
+            filename (str): HDF5 file to open.
+            quiet (bool): Quiets outputs if true.
+        """
+        self._h5_file = HDF5RawDataFile(filename)
+        self._set_tc_frag_paths(self._h5_file.get_all_fragment_dataset_paths())
+        self._quiet = quiet
+        self.run_id = self._h5_file.get_int_attribute('run_number')
+        self.file_index = self._h5_file.get_int_attribute('file_index')
+
+        return None
+
+    # TODO STYLE: Conforming to TAData and TPData, but this should be 'filter' not 'set'.
+    def _set_tc_frag_paths(self, fragment_paths: list[str]) -> None:
+        """
+        Filter fragment paths for TriggerCandidates.
+
+        Parameters:
+            fragment_paths (list[str]): List of fragment paths that can be loaded from.
+        Returns:
+            Nothing. Creates a new instance member self._fragment_paths list[str].
+        """
+        self._fragment_paths = []
+        for fragment_path in fragment_paths:
+            if 'Trigger_Candidate' in fragment_path:
+                self._fragment_paths.append(fragment_path)
+
+        return None
+
+    def get_tc_frag_paths(self) -> list[str]:
+        """ Returns the list of fragment paths. """
+        return self._fragment_paths
+
+    # TODO STYLE: Conforming to TAData and TPData, but this should be 'read_fragment'.
+    def load_frag(self, fragment_path: str) -> None:
+        """
+        Read from the given fragment path and store.
+
+        Parameters:
+            fragment_path (str): Fragment path to load from the initialized HDF5.
+        Returns:
+            Nothing. Stores the result in instance members :tc_data: and :ta_data:.
+        """
+        frag = self._h5_file.get_frag(fragment_path)
+        frag_data_size = frag.get_data_size()
+
+        if frag_data_size == 0:  # Empty fragment
+            self._num_empty += 1
+            if not self._quiet:
+                print(self._FAIL_TEXT_COLOR + self._BOLD_TEXT + "WARNING: Empty fragment." + self._END_TEXT_COLOR)
+                print(self._WARNING_TEXT_COLOR + self._BOLD_TEXT + f"INFO: Fragment Path: {fragment_path}" + self._END_TEXT_COLOR)
+
+        tc_idx = 0  # Debugging output.
+        byte_idx = 0  # Variable TC sizing, must do a while loop.
+        while byte_idx < frag_data_size:
+            if not self._quiet:
+                print(f"INFO: Fragment Index: {tc_idx}.")
+                tc_idx += 1
+                print(f"INFO: Byte Index / Frag Size: {byte_idx} / {frag_data_size}")
+
+            # Process TC data
+            tc_datum = trgdataformats.TriggerCandidate(frag.get_data_bytes(byte_idx))
+            np_tc_datum = np.array([(
+                tc_datum.data.algorithm,
+                tc_datum.data.detid,
+                tc_datum.n_inputs(),
+                tc_datum.data.time_candidate,
+                tc_datum.data.time_end,
+                tc_datum.data.time_start,
+                tc_datum.data.type,
+                tc_datum.data.version)],
+                dtype=self.tc_dt
+            )
+            self.tc_data = np.hstack((self.tc_data, np_tc_datum))
+
+            byte_idx += tc_datum.sizeof()
+            if not self._quiet:
+                print(f"Upcoming byte: {byte_idx}.")
+
+            # Process TA data
+            np_ta_data = np.zeros(np_tc_datum['num_tas'], dtype=self.ta_dt)
+            for ta_idx, ta in enumerate(tc_datum):
+                np_ta_data[ta_idx] = np.array(
+                    [(
+                        ta.adc_integral,
+                        ta.adc_peak,
+                        np.uint8(ta.algorithm),
+                        ta.channel_end,
+                        ta.channel_peak,
+                        ta.channel_start,
+                        np.uint16(ta.detid),
+                        ta.time_activity,
+                        ta.time_end,
+                        ta.time_peak,
+                        ta.time_start,
+                        np.uint8(ta.type),
+                        ta.version
+                    )],
+                    dtype=self.ta_dt
+                )
+            self.ta_data.append(np_ta_data)  # Jagged array
+
+        return None
+
+    # TODO STYLE: Conforming to TAData and TPData, but this should be 'read_all_fragments'.
+    def load_all_frags(self) -> None:
+        """
+        Read from all fragments in :self._fragment_paths:.
+
+        Returns:
+            Nothing. Stores the result in instance members :tc_data: and :ta_data:.
+        """
+        for frag_path in self._fragment_paths:
+            self.load_frag(frag_path)
+        if self._num_empty != 0 and not self._quiet:
+            print(
+                self._FAIL_TEXT_COLOR
+                + self._BOLD_TEXT
+                + f"WARNING: Skipped {self._num_empty} frags."
+                + self._END_TEXT_COLOR
+            )

--- a/python/trgtools/TCData.py
+++ b/python/trgtools/TCData.py
@@ -10,6 +10,7 @@ import daqdataformats
 from hdf5libs import HDF5RawDataFile
 import trgdataformats
 
+
 class TCData():
     """
     Class that reads a given HDF5 TPStream file and stores
@@ -66,7 +67,7 @@ class TCData():
             filename (str): HDF5 file to open.
             quiet (bool): Quiets outputs if true.
         """
-        self._h5_file = HDF5RawDataFile(filename)
+        self._h5_file = HDF5RawDataFile(os.path.expanduser(filename))
         self._set_tc_frag_paths(self._h5_file.get_all_fragment_dataset_paths())
         self._quiet = quiet
         self.run_id = self._h5_file.get_int_attribute('run_number')
@@ -111,8 +112,18 @@ class TCData():
         if frag_data_size == 0:  # Empty fragment
             self._num_empty += 1
             if not self._quiet:
-                print(self._FAIL_TEXT_COLOR + self._BOLD_TEXT + "WARNING: Empty fragment." + self._END_TEXT_COLOR)
-                print(self._WARNING_TEXT_COLOR + self._BOLD_TEXT + f"INFO: Fragment Path: {fragment_path}" + self._END_TEXT_COLOR)
+                print(
+                        self._FAIL_TEXT_COLOR
+                        + self._BOLD_TEXT
+                        + "WARNING: Empty fragment."
+                        + self._END_TEXT_COLOR
+                )
+                print(
+                        self._WARNING_TEXT_COLOR
+                        + self._BOLD_TEXT
+                        + f"INFO: Fragment Path: {fragment_path}"
+                        + self._END_TEXT_COLOR
+                )
 
         tc_idx = 0  # Debugging output.
         byte_idx = 0  # Variable TC sizing, must do a while loop.

--- a/python/trgtools/__init__.py
+++ b/python/trgtools/__init__.py
@@ -1,2 +1,3 @@
 from .TAData import TAData
 from .TPData import TPData
+from .TCData import TCData


### PR DESCRIPTION
There is now the `TCData` class and `tc_dump.py` plotting script that can be used for TC diagnostics. The detailed functionality of `tc_dump.py` is written in `docs/tc-dump.md`.

The `TCData` class is able to read and store the contents of an HDF5 file by filtering through the available TC data fragments. This data reader also displays loading information and warnings. This can be quieted on instantiation with `trgtools.TCData(hdf5_file_name, quiet=True)`.

Testing for the `TCData` class was done by reading TC data from HDF5 files interactively and through the `tc_dump.py` plotter. Testing on `tc_dump.py` was done for multiple files and checking the plots displayed meaningful information.

The Python style for these new files are more consistent with what I would like to have moving forward. It would be nice to make the appropriate style changes to the other two data readers and plotters, so this will likely show up as a future PR. Any comments on the style would be greatly appreciated.