### PR TITLE
Added TC Processing

### DIFF
--- a/apps/process_tpstream.cxx
+++ b/apps/process_tpstream.cxx
@@ -157,10 +157,8 @@ int main(int argc, char const *argv[])
   app.add_option("-o", output_file_path, "Output TPStream file path");
   std::string channel_map_name = "VDColdboxChannelMap";
   app.add_option("-m", channel_map_name, "Detector Channel Map");
-  // std::string plugin_name = "TriggerActivityMakerHorizontalMuonPlugin";
-  // app.add_option("-p", plugin_name, "Trigger Activity plugin name.");
   std::string config_name;
-  app.add_option("-j", config_name, "Trigger Activity config JSON to use.")->required();
+  app.add_option("-j", config_name, "Trigger Activity and Candidate config JSON to use.")->required();
   uint64_t skip_rec(0);
   app.add_option("-s", skip_rec, "Skip records");
   uint64_t num_rec(0);

--- a/apps/process_tpstream.cxx
+++ b/apps/process_tpstream.cxx
@@ -307,6 +307,13 @@ int main(int argc, char const *argv[])
       if (!quiet)
         fmt::print("  ta_buffer in bytes = {}\n", payload_size);
 
+      // Could be that a TA is empty; skip as it will show up in the next fragment.
+      // TC also gets skipped, but what's the use of trying to propagate a TC with no TAs?
+      if (payload_size == 0) {
+        if (!quiet)
+          fmt::print("Skipped saving an empty TA frag.");
+        continue;
+      }
       
       // Create the fragment buffer
       void* payload = malloc(payload_size);
@@ -380,6 +387,13 @@ int main(int argc, char const *argv[])
       // Print the total size
       if (!quiet)
         fmt::print("tc_buffer in bytes = {}\n", tc_payload_size);
+
+      // Could be that a TC is empty. Skip, as it will show up in the next fragment.
+      if (tc_payload_size == 0) {
+        if (!quiet)
+          fmt::print("Skipped saving an empty TC frag.");
+        continue;
+      }
 
       // Create the fragment buffer
       // Reuse the old payload since it's still defined.


### PR DESCRIPTION
Changes were made to include TC processing after completing the TA processing step. This also included a change to skip writing to file if the TA or TC buffer is found to be empty. In the case of skipping for TA writing, this also skips TC. In the case of skipping for TC, it does not skip writing for TA.

I found that the empty fragment problem occurs because the current operating fragment would sometimes not complete a TA/TC. The TA/TC maker would still contain the TPs/TAs, so the information is held while moving on to the next fragment.

This seems sufficient to me since this application is more on testing TA and TC generation (and, later, their quality), so a TA that appears in the next TimeSlice is better than an incomplete TA creating a new TimeSlice or the TA being trashed.

This was tested using run 23582 on Prescales and checked with the plotting scripts in this repo. There were no problems found from the plotting scripts.