### PR TITLE
Process Emulation Units & TA/TC Process Timing

### DIFF
--- a/apps/process_tpstream.cxx
+++ b/apps/process_tpstream.cxx
@@ -201,6 +201,8 @@ int main(int argc, char const *argv[])
   ta_maker->configure(ta_config);
   std::unique_ptr<trgtools::EmulateTAUnit> ta_emulator = std::make_unique<trgtools::EmulateTAUnit>();
   ta_emulator->set_maker(ta_maker);
+  // TODO: Use a better file naming scheme for CSV.
+  ta_emulator->set_timing_file("ta_timings_" + output_file_path.substr(0, output_file_path.rfind(".")) + ".csv");
 
 
   // Finally create a TA maker
@@ -209,6 +211,8 @@ int main(int argc, char const *argv[])
   tc_maker->configure(tc_config);
   std::unique_ptr<trgtools::EmulateTCUnit> tc_emulator = std::make_unique<trgtools::EmulateTCUnit>();
   tc_emulator->set_maker(tc_maker);
+  // TODO: Use a better file naming scheme for CSV.
+  tc_emulator->set_timing_file("tc_timings_" + output_file_path.substr(0, output_file_path.rfind(".")) + ".csv");
 
   // Generic filter hook
   std::function<bool(const trgdataformats::TriggerPrimitive&)> tp_filter;
@@ -282,7 +286,7 @@ int main(int argc, char const *argv[])
       //
 
       const auto ta_start = std::chrono::steady_clock::now();
-      std::unique_ptr<daqdataformats::Fragment> ta_frag = ta_emulator->emulate(tp_buffer);
+      std::unique_ptr<daqdataformats::Fragment> ta_frag = ta_emulator->emulate_vector(tp_buffer);
       const auto ta_end = std::chrono::steady_clock::now();
 
       if (ta_frag == nullptr) // Buffer was empty.
@@ -316,7 +320,7 @@ int main(int argc, char const *argv[])
 
       std::vector<triggeralgs::TriggerActivity> ta_buffer = ta_emulator->get_last_output_buffer();
       const auto tc_start = std::chrono::steady_clock::now();
-      std::unique_ptr<daqdataformats::Fragment> tc_frag = tc_emulator->emulate(ta_buffer);
+      std::unique_ptr<daqdataformats::Fragment> tc_frag = tc_emulator->emulate_vector(ta_buffer);
       const auto tc_end = std::chrono::steady_clock::now();
 
       if (tc_frag == nullptr) // Buffer was empty.

--- a/apps/process_tpstream.cxx
+++ b/apps/process_tpstream.cxx
@@ -338,8 +338,10 @@ int main(int argc, char const *argv[])
 
     } // Fragment for loop
 
-    average_ta_time /= num_tas;
-    average_tc_time /= num_tcs;
+    if (num_tas == 0) average_ta_time = 0;
+    else average_ta_time /= num_tas;
+    if (num_tcs == 0) average_tc_time = 0;
+    else average_tc_time /= num_tcs;
     if (!quiet) {
       fmt::print("\t\tAverage TA Time Process ({} TAs): {} ns.\n", num_tas, average_ta_time);
       fmt::print("\t\tAverage TC Time Process ({} TCs): {} ns.\n", num_tcs, average_tc_time);

--- a/docs/process-tpstream.md
+++ b/docs/process-tpstream.md
@@ -1,5 +1,5 @@
 # Processing TP Streams
-`process_tpstream.cxx` (and the application `trgtools_process_tpstream`) processes a timeslice HDF5 that contains TriggerPrimitives and creates a new HDF5 that also includes TriggerActivities and TriggerCandidates. The primary use of this is to test TA algorithms, TC algorithms, and their configurations, with output diagnostics available from `ta_dump.py` and `tc_dump.py`.
+`process_tpstream.cxx` (and the application `trgtools_process_tpstream`) processes a timeslice HDF5 that contains TriggerPrimitives and creates a new HDF5 that also includes TriggerActivities and TriggerCandidates. The primary use of this is to test TA algorithms, TC algorithms, and their configurations, with output diagnostics available from `ta_dump.py` and `tc_dump.py`. The application also outputs the time in nanoseconds to create a new TA/TC given a new TP/TA to a CSV file in the format: row as a fragment and new TP/TA as each entry in that row. Many of the entries will have a value 0 because they did not result in creating a new TA/TC and can be ignored.
 
 ## Example
 ```bash

--- a/include/trgtools/EmulateTAUnit.hpp
+++ b/include/trgtools/EmulateTAUnit.hpp
@@ -1,0 +1,27 @@
+/* @file: EmulateTAUnit.hpp
+ *
+ * Emulation unit for TriggerActivities.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2023.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRGTOOLS_EMULATETAUNIT_HPP_
+#define TRGTOOLS_EMULATETAUNIT_HPP_
+
+#include "trgtools/EmulationUnit.hpp"
+#include "trgdataformats/TriggerPrimitive.hpp"
+#include "triggeralgs/TriggerActivityMaker.hpp"
+
+namespace dunedaq {
+namespace trgtools {
+
+class EmulateTAUnit
+  : public EmulationUnit<trgdataformats::TriggerPrimitive, triggeralgs::TriggerActivity, triggeralgs::TriggerActivityMaker>
+{};
+
+} // namespace trgtools
+} // namespace dunedaq
+
+#endif // TRGTOOLS_EMULATETAUNIT_HPP_

--- a/include/trgtools/EmulateTCUnit.hpp
+++ b/include/trgtools/EmulateTCUnit.hpp
@@ -1,0 +1,29 @@
+/* @file: EmulateTCUnit.hpp
+ *
+ * Emulation unit for TriggerCandidates.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2023.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRGTOOLS_EMULATETCUNIT_HPP_
+#define TRGTOOLS_EMULATETCUNIT_HPP_
+
+#include "trgtools/EmulationUnit.hpp"
+#include "triggeralgs/TriggerActivity.hpp"
+#include "triggeralgs/TriggerCandidateMaker.hpp"
+
+namespace dunedaq {
+namespace trgtools {
+
+class EmulateTCUnit
+  : public EmulationUnit<triggeralgs::TriggerActivity,
+                         triggeralgs::TriggerCandidate,
+                         triggeralgs::TriggerCandidateMaker>
+{};
+
+} // namespace trgtools
+} // namespace dunedaq
+
+#endif // TRGTOOLS_EMULATETAUNIT_HPP_

--- a/include/trgtools/EmulationUnit.hpp
+++ b/include/trgtools/EmulationUnit.hpp
@@ -14,6 +14,9 @@
 #include "daqdataformats/Fragment.hpp"
 #include "triggeralgs/TriggerObjectOverlay.hpp"
 
+#include <chrono>
+#include <fstream>
+#include <iostream>
 #include <memory>
 #include <vector>
 
@@ -30,11 +33,14 @@ class EmulationUnit
   private:
     std::unique_ptr<maker_t> m_maker; // TODO: unique may become shared later.
     std::vector<output_t> m_last_output_buffer;
+    std::string m_timing_file_name;
 
   public:
-    std::unique_ptr<daqdataformats::Fragment> emulate(const std::vector<input_t>& inputs);
+    uint64_t emulate(const input_t& input, std::vector<output_t>& outputs);
+    std::unique_ptr<daqdataformats::Fragment> emulate_vector(const std::vector<input_t>& inputs);
     std::vector<output_t> get_last_output_buffer();
     void set_maker(std::unique_ptr<maker_t>& maker) { m_maker = std::move(maker); }
+    void set_timing_file(const std::string& file_name) { m_timing_file_name = file_name; }
 };
 
 } // namespace trgtools

--- a/include/trgtools/EmulationUnit.hpp
+++ b/include/trgtools/EmulationUnit.hpp
@@ -1,0 +1,45 @@
+/* @file: EmulationUnit.hpp
+ *
+ * Base abstract class for emulation units.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2023.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRGTOOLS_EMULATIONUNIT_HPP_
+#define TRGTOOLS_EMULATIONUNIT_HPP_
+
+#include "daqdataformats/TimeSlice.hpp"
+#include "daqdataformats/Fragment.hpp"
+#include "triggeralgs/TriggerObjectOverlay.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace dunedaq {
+namespace trgtools {
+
+template <typename T, typename U, typename V>
+class EmulationUnit
+{
+  using input_t = T;
+  using output_t = U;
+  using maker_t = V;
+
+  private:
+    std::unique_ptr<maker_t> m_maker; // TODO: unique may become shared later.
+    std::vector<output_t> m_last_output_buffer;
+
+  public:
+    std::unique_ptr<daqdataformats::Fragment> emulate(const std::vector<input_t>& inputs);
+    std::vector<output_t> get_last_output_buffer();
+    void set_maker(std::unique_ptr<maker_t>& maker) { m_maker = std::move(maker); }
+};
+
+} // namespace trgtools
+} // namespace dunedaq
+
+#include "detail/EmulationUnit.hxx"
+
+#endif // TRGTOOLS_EMULATIONUNIT_HPP_

--- a/include/trgtools/detail/EmulationUnit.hxx
+++ b/include/trgtools/detail/EmulationUnit.hxx
@@ -64,9 +64,16 @@ EmulationUnit<T, U, V>::emulate_vector(const std::vector<T>& inputs) {
 template <typename T, typename U, typename V>
 uint64_t
 EmulationUnit<T, U, V>::emulate(const T& input, std::vector<U>& outputs) {
+  int size_before = outputs.size();
   auto time_start = std::chrono::steady_clock::now();
   (*m_maker)(input, outputs); // Feed TX into the TXMaker
   auto time_end = std::chrono::steady_clock::now();
+
+  // Only care about the timing for a TP/TA that made a TA/TC.
+  // Return 0 for TPs/TAs that didn't close.
+  if (outputs.size() == size_before)
+    return 0;
+
   uint64_t time_diff = std::chrono::nanoseconds(time_end - time_start).count();
   return time_diff;
 }

--- a/include/trgtools/detail/EmulationUnit.hxx
+++ b/include/trgtools/detail/EmulationUnit.hxx
@@ -1,0 +1,61 @@
+/* @file EmulationUnit.hxx
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2023.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef TRGTOOLS_EMULATIONUNIT_HXX_
+#define TRGTOOLS_EMULATIONUNIT_HXX_
+
+namespace dunedaq {
+namespace trgtools {
+
+template <typename T, typename U, typename V>
+std::unique_ptr<daqdataformats::Fragment>
+EmulationUnit<T, U, V>::emulate(const std::vector<T>& inputs) {
+  // Create the output.
+  std::vector<U> output_buffer;
+
+  for (const T& input : inputs) {
+    (*m_maker)(input, output_buffer); // Feed TX into the TXMaker
+  }
+
+  // Get the size to save on.
+  size_t payload_size(0);
+  for (const U& output : output_buffer) {
+    payload_size += triggeralgs::get_overlay_nbytes(output);
+  }
+
+  // Don't save empty fragments.
+  // The incomplete TX contents will get pushed onto the next fragment.
+  if (payload_size == 0)
+    return nullptr;
+
+  void* payload = malloc(payload_size);
+  size_t payload_offset(0);
+  for (const U& output : output_buffer) {
+    triggeralgs::write_overlay(output, payload + payload_offset);
+    payload_offset += triggeralgs::get_overlay_nbytes(output);
+  }
+
+  // Hand it to a fragment,
+  std::unique_ptr<daqdataformats::Fragment> frag
+    = std::make_unique<daqdataformats::Fragment>(payload, payload_size);
+  // And release it.
+  free(payload);
+
+  m_last_output_buffer = output_buffer;
+  return frag;
+}
+
+template <typename T, typename U, typename V>
+std::vector<U>
+EmulationUnit<T, U, V>::get_last_output_buffer() {
+  return m_last_output_buffer;
+}
+
+} // namespace trgtools
+} // namespace dunedaq
+
+#endif // TRGTOOLS_EMULATIONUNIT_HXX_


### PR DESCRIPTION
The sections in `process_tpstream.cxx` that handle the TAs and TCs were very similar, so I've made a templated abstract `EmulationUnit` that does the same process. Then `EmulateTAUnit` and `EmulateTCUnit` fill in the templates. This will make adjustments, such as adding TPSets and TASets, easier in the future.

At the same time, I've added some naive timings based on when these emulation units start and end. The result for each individual TA/TC fragment is then printed, and an average for the TimeSlice is also printed.

This was tested on NP02 TPStream run 23582 by cross checking that the plotting scripts for TA and TC were consistent before and after the `process_tpstream.cxx` changes.