### PR TITLE
Fixed Shared TXReader Data Members

### DIFF
--- a/python/trgtools/HDF5Reader.py
+++ b/python/trgtools/HDF5Reader.py
@@ -20,8 +20,6 @@ class HDF5Reader(abc.ABC):
     _BOLD_TEXT = '\033[1m'
     _END_TEXT_COLOR = '\033[0m'
 
-    # Counts the number of empty fragments.
-    _num_empty = 0
 
     def __init__(self, filename: str, verbosity: int = 0) -> None:
         """
@@ -42,6 +40,8 @@ class HDF5Reader(abc.ABC):
         self._verbosity = verbosity
 
         self._filter_fragment_paths()  # Derived class must define this.
+
+        self._num_empty = 0  # Counts the number of empty fragments.
 
         return None
 

--- a/python/trgtools/TAReader.py
+++ b/python/trgtools/TAReader.py
@@ -39,7 +39,6 @@ class TAReader(HDF5Reader):
                       ('type', np.uint8),
                       ('version', np.uint16)
                      ])
-    ta_data = np.array([], dtype=ta_dt)
 
     # TP data type
     tp_dt = np.dtype([
@@ -55,7 +54,6 @@ class TAReader(HDF5Reader):
                       ('type', np.uint8),
                       ('version', np.uint16)
                      ])
-    tp_data = []
 
     def __init__(self, filename: str, verbosity: int = 0) -> None:
         """
@@ -68,6 +66,8 @@ class TAReader(HDF5Reader):
         Returns nothing.
         """
         super().__init__(filename, verbosity)
+        self.ta_data = np.array([], dtype=self.ta_dt)
+        self.tp_data = []
         return None
 
     def _filter_fragment_paths(self) -> None:

--- a/python/trgtools/TCReader.py
+++ b/python/trgtools/TCReader.py
@@ -33,7 +33,6 @@ class TCReader(HDF5Reader):
         ('type', np.uint8),
         ('version', np.uint16),
     ])
-    tc_data = np.array([], dtype=tc_dt)  # Will concatenate new TCs
 
     # TA data type
     ta_dt = np.dtype([
@@ -51,7 +50,6 @@ class TCReader(HDF5Reader):
         ('type', np.uint8),
         ('version', np.uint16)
     ])
-    ta_data = []  # ta_data[i] will be a np.ndarray of TAs from the i-th TC
 
     def __init__(self, filename: str, verbosity: int = 0) -> None:
         """
@@ -64,6 +62,8 @@ class TCReader(HDF5Reader):
         Returns nothing.
         """
         super().__init__(filename, verbosity)
+        self.tc_data = np.array([], dtype=self.tc_dt)  # Will concatenate new TCs
+        self.ta_data = []  # ta_data[i] will be a np.ndarray of TAs from the i-th TC
         return None
 
     def _filter_fragment_paths(self) -> None:
@@ -157,4 +157,4 @@ class TCReader(HDF5Reader):
 
     def clear_data(self) -> None:
         self.tc_data = np.array([], dtype=self.tc_dt)
-        ta_data = []
+        self.ta_data = []

--- a/python/trgtools/TPReader.py
+++ b/python/trgtools/TPReader.py
@@ -36,7 +36,6 @@ class TPReader(HDF5Reader):
                       ('type', np.uint8),
                       ('version', np.uint16)
                      ])
-    tp_data = np.array([], dtype=tp_dt)
 
     def __init__(self, filename: str, verbosity: int = 0) -> None:
         """
@@ -49,6 +48,7 @@ class TPReader(HDF5Reader):
         Returns nothing.
         """
         super().__init__(filename, verbosity)
+        self.tp_data = np.array([], dtype=self.tp_dt)
         return None
 
     def _filter_fragment_paths(self) -> None:


### PR DESCRIPTION
While loading multiple data files at once, I noticed that reading in the first `TXReader` would mutate the second `TXReader`. In particular this was affecting `TAReader.tp_data` and similarly for `TCReader.ta_data`. I found that this is due to the `list` and class structure in Python, so I've moved the placement of the definitions to avoid this problem.

This was tested with a script that loads two data sources in various orders:
- Instance and read `data0` then instance and read `data1`.
- Instance `data0` and `data1` then read `data0` and `data1`.
- Instance and read `data0` and `data1` in separate function scopes.

Before this change, `data1` would always see the changes made in `data0`. After this change, `data1` gained independence.