### PR TITLE
Fixed multi-fragment TimeSlice processing.

### DIFF
--- a/apps/process_tpstream.cxx
+++ b/apps/process_tpstream.cxx
@@ -225,7 +225,8 @@ int main(int argc, char const *argv[])
 
   rp.set_processor([&]( daqdataformats::TimeSlice& tsl ) -> void {
     const std::vector<std::unique_ptr<daqdataformats::Fragment>>& frags = tsl.get_fragments_ref();
-    fmt::print("The numbert of fragments: {}\n", frags.size());
+    const size_t num_frags = frags.size();
+    fmt::print("The number of fragments: {}\n", num_frags);
 
     uint64_t average_ta_time = 0;
     uint64_t average_tc_time = 0;
@@ -233,7 +234,9 @@ int main(int argc, char const *argv[])
     size_t num_tas = 0;
     size_t num_tcs = 0;
 
-    for( const auto& frag : frags ) {
+    // Need a static for-loop: adding fragments to tsl will mutate frags even though it's const.
+    for (int i = 0; i < num_frags; i++) {
+      const auto& frag = frags[i];
 
       // The fragment has to be for the trigger (not e.g. for retreival from readout)
       if (frag->get_element_id().subsystem != tp_subsystem_requirement) {


### PR DESCRIPTION
There was a problem with segfaulting when emulating on a TPStream with multiple TP fragments per TimeSlice. This is due to the TimeSlice's fragments getting mutated while doing a for-each loop and invalidating the end.

I've changed this to use a for-loop over the indices of the fragments vector and stop at the initial size of this vector. The order of this vector is not changed, so this completes as intended.

This was tested by using a single fragment per TimeSlice file and a file with multiple fragments per TimeSlice and checking the results with each `tx_dump.py`.