### PR TITLE
Use trgdataformats TC Py-capsule.

### DIFF
--- a/python/trgtools/TCReader.py
+++ b/python/trgtools/TCReader.py
@@ -112,7 +112,7 @@ class TCReader(HDF5Reader):
                 print(f"INFO: Byte Index / Frag Size: {byte_idx} / {fragment_data_size}")
 
             # Process TC data
-            tc_datum = trgdataformats.TriggerCandidate(fragment.get_data_bytes(byte_idx))
+            tc_datum = trgdataformats.TriggerCandidate(fragment.get_data(byte_idx))
             np_tc_datum = np.array([(
                                 tc_datum.data.algorithm,
                                 tc_datum.data.detid,


### PR DESCRIPTION
Propagating the change here https://github.com/DUNE-DAQ/trgdataformats/pull/24. Using this pybind consistently gets all TCs from a fragment while the byte version does not.

To test, do
```python
from trgtools import TCReader

tc_data = TCReader("/data0/np04hd_raw_run027103_0000_dataflow0_datawriter_0_20240617T081743.hdf5.copied")
tc_data.read_all_fragments()
print(tc_data.tc_data['type'])
```

Before the change, there will be fewer TCs and all of the same type. After the change, there should be more TCs and of different types.