### PR TITLE
trgdataformats Enum Update Propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/
 
 cmake_minimum_required(VERSION 3.12)
-project(trgtools VERSION 1.1.1)
+project(trgtools VERSION 1.1.2)
 
 find_package(daq-cmake REQUIRED)
 find_package(CLI11 REQUIRED)

--- a/python/trgtools/TAReader.py
+++ b/python/trgtools/TAReader.py
@@ -26,7 +26,7 @@ class TAReader(HDF5Reader):
     ta_dt = np.dtype([
                       ('adc_integral', np.uint64),
                       ('adc_peak', np.uint64),
-                      ('algorithm', np.uint8),
+                      ('algorithm', trgdataformats.TriggerActivityData.Algorithm),
                       ('channel_end', np.int32),
                       ('channel_peak', np.int32),
                       ('channel_start', np.int32),
@@ -36,7 +36,7 @@ class TAReader(HDF5Reader):
                       ('time_end', np.uint64),
                       ('time_peak', np.uint64),
                       ('time_start', np.uint64),
-                      ('type', np.uint8),
+                      ('type', trgdataformats.TriggerActivityData.Type),
                       ('version', np.uint16)
                      ])
 
@@ -44,14 +44,14 @@ class TAReader(HDF5Reader):
     tp_dt = np.dtype([
                       ('adc_integral', np.uint32),
                       ('adc_peak', np.uint32),
-                      ('algorithm', np.uint8),
+                      ('algorithm', trgdataformats.TriggerPrimitive.Algorithm),
                       ('channel', np.int32),
                       ('detid', np.uint16),
                       ('flag', np.uint16),
                       ('time_over_threshold', np.uint64),
                       ('time_peak', np.uint64),
                       ('time_start', np.uint64),
-                      ('type', np.uint8),
+                      ('type', trgdataformats.TriggerPrimitive.Type),
                       ('version', np.uint16)
                      ])
 

--- a/python/trgtools/TCReader.py
+++ b/python/trgtools/TCReader.py
@@ -24,13 +24,13 @@ class TCReader(HDF5Reader):
     """
     # TC data type
     tc_dt = np.dtype([
-        ('algorithm', np.uint8),
+        ('algorithm', trgdataformats.TriggerCandidateData.Algorithm),
         ('detid', np.uint16),
         ('num_tas', np.uint64),  # Greedy
         ('time_candidate', np.uint64),
         ('time_end', np.uint64),
         ('time_start', np.uint64),
-        ('type', np.uint8),
+        ('type', trgdataformats.TriggerCandidateData.Type),
         ('version', np.uint16),
     ])
 
@@ -38,7 +38,7 @@ class TCReader(HDF5Reader):
     ta_dt = np.dtype([
         ('adc_integral', np.uint64),
         ('adc_peak', np.uint64),
-        ('algorithm', np.uint8),
+        ('algorithm', trgdataformats.TriggerActivityData.Algorithm),
         ('channel_end', np.int32),
         ('channel_peak', np.int32),
         ('channel_start', np.int32),
@@ -47,7 +47,7 @@ class TCReader(HDF5Reader):
         ('time_end', np.uint64),
         ('time_peak', np.uint64),
         ('time_start', np.uint64),
-        ('type', np.uint8),
+        ('type', trgdataformats.TriggerActivityData.Type),
         ('version', np.uint16)
     ])
 

--- a/python/trgtools/TPReader.py
+++ b/python/trgtools/TPReader.py
@@ -26,14 +26,14 @@ class TPReader(HDF5Reader):
     tp_dt = np.dtype([
                       ('adc_integral', np.uint32),
                       ('adc_peak', np.uint32),
-                      ('algorithm', np.uint8),
+                      ('algorithm', trgdataformats.TriggerPrimitive.Algorithm),
                       ('channel', np.int32),
                       ('detid', np.uint16),
                       ('flag', np.uint16),
                       ('time_over_threshold', np.uint64),
                       ('time_peak', np.uint64),
                       ('time_start', np.uint64),
-                      ('type', np.uint8),
+                      ('type', trgdataformats.TriggerPrimitive.Type),
                       ('version', np.uint16)
                      ])
 

--- a/scripts/ta_dump.py
+++ b/scripts/ta_dump.py
@@ -6,6 +6,8 @@ tpstream file.
 import trgtools
 from trgtools.plot import PDFPlotter
 
+import trgdataformats
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
@@ -14,6 +16,11 @@ from scipy import stats
 import os
 import argparse
 
+
+ALGORITHM_LABELS = list(trgdataformats.TriggerActivityData.Algorithm.__members__.keys())
+ALGORITHM_TICKS = [ta_alg.value for tp_alg in trgdataformats.TriggerActivityData.Algorithm.__members__.values()]
+TYPE_LABELS = list(trgdataformats.TriggerActivityData.Type.__members__.keys())
+TYPE_TICKS = [ta_type.value for tp_type in trgdataformats.TriggerActivityData.Type.__members__.values()]
 
 TICK_TO_SEC_SCALE = 16e-9  # s per tick
 
@@ -332,29 +339,19 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'algorithm': {
+                'bins': np.arange(-0.5, np.max(ALGORITHM_TICKS) + 1, 1),
                 'title': "Algorithm Histogram",
                 'xlabel': 'Algorithm Type',
                 'ylabel': "Count",
                 'linear': True,  # TODO: Hard set for now.
                 'linear_style': dict(color='k'),
                 'log': False,
-                'bins': 8,
-                'xlim': (-0.5, 7.5),
                 'xticks': {
-                    'ticks': range(0, 8),  # xticks to change
-                    'labels': (
-                        "Unknown",
-                        "Supernova",
-                        "Prescale",
-                        "ADCSimpleWindow",
-                        "HorizontalMuon",
-                        "MichelElectron",
-                        "DBSCAN",
-                        "PlaneCoincidence"
-                    ),
-                    'rotation': 60,
-                    'ha': 'right'  # Horizontal alignment
-                }
+                        'labels': ALGORITHM_LABELS,
+                        'ticks': ALGORITHM_TICKS,
+                        'rotation': 60,
+                        'ha': 'right'  # Horizontal alignment
+                    }
             },
             # TODO: Channel data members should bin on
             # the available channels; however, this is
@@ -442,20 +439,19 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'type': {
+                'bins': np.arange(-0.5, np.max(TYPE_TICKS) + 1, 1),
                 'title': "Type Histogram",
                 'xlabel': "Type",
                 'ylabel': "Count",
                 'linear': True,  # TODO: Hard set for now.
                 'linear_style': dict(color='k'),
                 'log': False,
-                'bins': 3,
-                'xlim': (-0.5, 2.5),
                 'xticks': {
-                    'ticks': (0, 1, 2),  # Ticks to change
-                    'labels': ('Unknown', 'TPC', 'PDS'),
-                    'rotation': 60,
-                    'ha': 'right'  # Horizontal alignment
-                }
+                        'labels': TYPE_LABELS,
+                        'ticks': TYPE_TICKS,
+                        'rotation': 60,
+                        'ha': 'right'  # Horizontal alignment
+                    }
             },
             'version': {
                 'title': "Version Histogram",
@@ -479,6 +475,14 @@ def main():
             pdf_plotter.plot_histogram(time - min_time, plot_hist_dict[ta_key])
             if not no_anomaly:
                 write_summary_stats(time - min_time, anomaly_filename, ta_key)
+            continue
+
+        if ta_key == 'algorithm' or ta_key == 'type':  # Special case.
+            plot_data = np.array([datum.value for datum in data.ta_data[ta_key]], dtype=int)
+            pdf_plotter.plot_histogram(plot_data, plot_hist_dict[ta_key])
+            if not no_anomaly:
+                write_summary_stats(plot_data, anomaly_filename, ta_key)
+            del plot_data
             continue
 
         pdf_plotter.plot_histogram(data.ta_data[ta_key], plot_hist_dict[ta_key])

--- a/scripts/ta_dump.py
+++ b/scripts/ta_dump.py
@@ -18,9 +18,9 @@ import argparse
 
 
 ALGORITHM_LABELS = list(trgdataformats.TriggerActivityData.Algorithm.__members__.keys())
-ALGORITHM_TICKS = [ta_alg.value for tp_alg in trgdataformats.TriggerActivityData.Algorithm.__members__.values()]
+ALGORITHM_TICKS = [ta_alg.value for ta_alg in trgdataformats.TriggerActivityData.Algorithm.__members__.values()]
 TYPE_LABELS = list(trgdataformats.TriggerActivityData.Type.__members__.keys())
-TYPE_TICKS = [ta_type.value for tp_type in trgdataformats.TriggerActivityData.Type.__members__.values()]
+TYPE_TICKS = [ta_type.value for ta_type in trgdataformats.TriggerActivityData.Type.__members__.values()]
 
 TICK_TO_SEC_SCALE = 16e-9  # s per tick
 

--- a/scripts/tc_dump.py
+++ b/scripts/tc_dump.py
@@ -6,6 +6,8 @@ tpstream file.
 import trgtools
 from trgtools.plot import PDFPlotter
 
+import trgdataformats
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
@@ -14,6 +16,11 @@ from scipy import stats
 import os
 import argparse
 
+
+ALGORITHM_LABELS = list(trgdataformats.TriggerCandidateData.Algorithm.__members__.keys())
+ALGORITHM_TICKS = [tp_alg.value for tp_alg in trgdataformats.TriggerCandidateData.Algorithm.__members__.values()]
+TYPE_LABELS = list(trgdataformats.TriggerCandidateData.Type.__members__.keys())
+TYPE_TICKS = [tp_type.value for tp_type in trgdataformats.TriggerCandidateData.Type.__members__.values()]
 
 TICK_TO_SEC_SCALE = 16e-9  # s per tick
 
@@ -308,30 +315,19 @@ def main():
     # Dictionary containing unique title, xlabel, and xticks (only some)
     plot_hist_dict = {
             'algorithm': {
-                'bins': np.arange(-0.5, 9.5, 1),
+                'bins': np.arange(-0.5, np.max(ALGORITHM_TICKS) + 1, 1),
                 'title': "Algorithm",
                 'xlabel': 'Algorithm Type',
                 'ylabel': "Count",
                 'linear': True,  # TODO: Hard set for now.
                 'linear_style': dict(color='k'),
                 'log': False,
-                'xlim': (-1, 9),
                 'xticks': {
-                    'ticks': range(0, 9),
-                    'labels': (
-                        "Unknown",
-                        "Supernova",
-                        "HSIEventToTriggerCandidate",
-                        "Prescale",
-                        "ADCSimpleWindow",
-                        "HorizontalMuon",
-                        "MichelElectron",
-                        "PlaneCoincidence",
-                        "Custom"
-                    ),
-                    'rotation': 60,
-                    'ha': 'right'  # Horizontal alignment
-                }
+                        'labels': ALGORITHM_LABELS,
+                        'ticks': ALGORITHM_TICKS,
+                        'rotation': 60,
+                        'ha': 'right'  # Horizontal alignment
+                    }
             },
             'detid': {
                 'title': "Detector ID",
@@ -388,30 +384,18 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'type': {
-                'bins': np.arange(-0.5, 10.5, 1),
+                'bins': np.arange(-0.5, np.max(TYPE_TICKS) + 1, 1),
                 'title': "Type",
                 'xlabel': "Type",
                 'ylabel': "Count",
                 'linear': True,  # TODO: Hard set for now.
                 'linear_style': dict(color='k'),
                 'log': False,
-                'xlim': (-1, 10),
                 'xticks': {
-                    'ticks': range(0, 10),
-                    'labels': (
-                        'Unknown',
-                        'Timing',
-                        'TPCLowE',
-                        'Supernova',
-                        'Random',
-                        'Prescale',
-                        'ADCSimpleWindow',
-                        'HorizontalMuon',
-                        'MichelElectron',
-                        'PlaneCoincidence'
-                        ),
-                    'rotation': 60,
-                    'ha': 'right'  # Horizontal alignment
+                        'labels': TYPE_LABELS,
+                        'ticks': TYPE_TICKS,
+                        'rotation': 60,
+                        'ha': 'right'  # Horizontal alignment
                     }
             },
             'version': {
@@ -439,6 +423,14 @@ def main():
                 write_summary_stats(time - min_time, anomaly_filename, tc_key)
             continue
 
+        if tc_key == 'algorithm' or tc_key == 'type':  # Special case.
+            plot_data = np.array([datum.value for datum in data.tc_data[tc_key]], dtype=int)
+            pdf_plotter.plot_histogram(plot_data, plot_hist_dict[tc_key])
+            if not no_anomaly:
+                write_summary_stats(plot_data, anomaly_filename, tc_key)
+            del plot_data
+            continue
+
         pdf_plotter.plot_histogram(data.tc_data[tc_key], plot_hist_dict[tc_key])
         if not no_anomaly:
             write_summary_stats(data.tc_data[tc_key], anomaly_filename, tc_key)
@@ -446,34 +438,37 @@ def main():
     pdf = pdf_plotter.get_pdf()
     # Analysis plots
     # ==== Time Delta Comparisons =====
-    if linear:
-        plot_pdf_time_delta_histograms(data.tc_data, data.ta_data, pdf, time_label, False)
-    if log:
-        plot_pdf_time_delta_histograms(data.tc_data, data.ta_data, pdf, time_label, True)
+    if np.sum(data.tc_data['num_tas']) > 0:
+        if linear:
+            plot_pdf_time_delta_histograms(data.tc_data, data.ta_data, pdf, time_label, False)
+        if log:
+            plot_pdf_time_delta_histograms(data.tc_data, data.ta_data, pdf, time_label, True)
     # =================================
 
     # ==== TC ADC Integrals ====
-    tc_adc_integrals = np.array([np.sum(tas['adc_integral']) for tas in data.ta_data])
-    adc_integrals_dict = {
-            'title': "TC ADC Integrals",
-            'xlabel': "ADC Integral",
-            'ylabel': "Count"
-    }
-    pdf_plotter.plot_histogram(tc_adc_integrals, adc_integrals_dict)
+    if np.sum(data.tc_data['num_tas']) > 0:
+        tc_adc_integrals = np.array([np.sum(tas['adc_integral']) for tas in data.ta_data])
+        adc_integrals_dict = {
+                'title': "TC ADC Integrals",
+                'xlabel': "ADC Integral",
+                'ylabel': "Count"
+        }
+        pdf_plotter.plot_histogram(tc_adc_integrals, adc_integrals_dict)
     # ==========================
 
     # ==== ADC Integral vs Number of TAs ====
-    integral_vs_num_tas_dict = {
-            'title': "TC ADC Integral vs Number of TAs",
-            'xlabel': "Number of TAs",
-            'ylabel': "TC ADC Integral",
-            'scatter_style': {
-                'alpha': 0.6,
-                'c': 'k',
-                's': 2
-            }
-    }
-    plot_pdf_scatter(data.tc_data['num_tas'], tc_adc_integrals, integral_vs_num_tas_dict, pdf)
+    if np.sum(data.tc_data['num_tas']) > 0:
+        integral_vs_num_tas_dict = {
+                'title': "TC ADC Integral vs Number of TAs",
+                'xlabel': "Number of TAs",
+                'ylabel': "TC ADC Integral",
+                'scatter_style': {
+                    'alpha': 0.6,
+                    'c': 'k',
+                    's': 2
+                }
+        }
+        plot_pdf_scatter(data.tc_data['num_tas'], tc_adc_integrals, integral_vs_num_tas_dict, pdf)
     # =======================================
 
     # ==== Time Spans Per TC ====

--- a/scripts/tp_dump.py
+++ b/scripts/tp_dump.py
@@ -6,6 +6,8 @@ tpstream file.
 import trgtools
 from trgtools.plot import PDFPlotter
 
+import trgdataformats
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
@@ -14,6 +16,11 @@ from scipy import stats
 import os
 import argparse
 
+
+ALGORITHM_LABELS = list(trgdataformats.TriggerPrimitive.Algorithm.__members__.keys())
+ALGORITHM_TICKS = [tp_alg.value for tp_alg in trgdataformats.TriggerPrimitive.Algorithm.__members__.values()]
+TYPE_LABELS = list(trgdataformats.TriggerPrimitive.Type.__members__.keys())
+TYPE_TICKS = [tp_type.value for tp_type in trgdataformats.TriggerPrimitive.Type.__members__.values()]
 
 TICK_TO_SEC_SCALE = 16e-9  # s per tick
 
@@ -291,18 +298,19 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'algorithm': {
+                'bins': np.arange(-0.5, np.max(ALGORITHM_TICKS) + 1, 1),
                 'title': "Algorithm Histogram",
                 'xlabel': 'Algorithm Type',
                 'ylabel': "Count",
                 'linear': True,  # TODO: Hard set for now
                 'linear_style': dict(color='k'),
                 'log': False,
-                'xlim': (-1, 2),
                 'xticks': {
-                    'ticks': (0, 1),
-                    'labels': ("Unknown", "TPCDefault")
-                },
-                'bins': (-0.5, 0.5, 1.5)  # TODO: Dangerous. Hides values outside of this range.
+                        'labels': ALGORITHM_LABELS,
+                        'ticks': ALGORITHM_TICKS,
+                        'rotation': 60,
+                        'ha': 'right'  # Horizontal alignment
+                    }
             },
             # TODO: Channel should bin on the available
             # channels; however, this is inconsistent
@@ -363,18 +371,19 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'type': {
+                'bins': np.arange(-0.5, np.max(TYPE_TICKS) + 1, 1),
                 'title': "Type Histogram",
                 'xlabel': "Type",
                 'ylabel': "Count",
                 'linear': True,  # TODO: Hard set for now
                 'linear_style': dict(color='k'),
                 'log': False,
-                'xlim': (-1, 3),
                 'xticks': {
-                    'ticks': (0, 1, 2),
-                    'labels': ('Unknown', 'TPC', 'PDS')
-                },
-                'bins': (-0.5, 0.5, 1.5, 2.5)  # TODO: Dangerous. Hides values outside of this range.
+                        'labels': TYPE_LABELS,
+                        'ticks': TYPE_TICKS,
+                        'rotation': 60,
+                        'ha': 'right'  # Horizontal alignment
+                    }
             },
             'version': {
                 'title': "Version Histogram",
@@ -399,6 +408,14 @@ def main():
             pdf_plotter.plot_histogram(time - min_time, plot_hist_dict[tp_key])
             if not no_anomaly:
                 write_summary_stats(time - min_time, anomaly_filename, tp_key)
+            continue
+
+        if tp_key == 'algorithm' or tp_key == 'type':  # Special case.
+            plot_data = np.array([datum.value for datum in data.tp_data[tp_key]], dtype=int)
+            pdf_plotter.plot_histogram(plot_data, plot_hist_dict[tp_key])
+            if not no_anomaly:
+                write_summary_stats(plot_data, anomaly_filename, tp_key)
+            del plot_data
             continue
 
         pdf_plotter.plot_histogram(data.tp_data[tp_key], plot_hist_dict[tp_key])


### PR DESCRIPTION
Propagating the changes in https://github.com/DUNE-DAQ/trgdataformats/pull/25. Using the updated enums allowed the removal of hard-coded values when plotting Algorithm and Type for each of TP, TA, and TC. This also closes #20.

Testing this can be done with any file containing TPs, TAs, and/or TCs with
```python
ta_dump.py --start-frag 2 --end-frag 5 <filename>
```
and continuing with `tp_dump.py` and `tc_dump.py`.

Here are some sample, updated plots:
![image](https://github.com/DUNE-DAQ/trgtools/assets/5084895/22dca1bc-c624-4da7-8e65-efb3ee2e362c)
![image](https://github.com/DUNE-DAQ/trgtools/assets/5084895/41cc1d17-828c-4e23-bfe5-3389d6982d5a)

(Note: the above plots also contain the changes produced by https://github.com/DUNE-DAQ/trgdataformats/pull/31.)

![image](https://github.com/DUNE-DAQ/trgtools/assets/5084895/07cfd1a6-8d6c-473d-8e0e-f6f9c446341f)
![image](https://github.com/DUNE-DAQ/trgtools/assets/5084895/c9319cbd-8c9c-4afd-a64d-56311ac53336)