### PR TITLE
Plotting Style Update

### DIFF
--- a/python/trgtools/plot/PDFPlotter.py
+++ b/python/trgtools/plot/PDFPlotter.py
@@ -130,6 +130,17 @@ class PDFPlotter:
             ax.patch.set_visible(False)
             ax2.set_zorder(1)
 
+            linear_color = plot_details_dict.get('linear_style', self._DEFAULT_HIST_STYLE).get('color', self._DEFAULT_HIST_STYLE['linear_style']['color'])
+            # Set axis and tick colors.
+            ax.spines['left'].set_color(linear_color)
+            ax.yaxis.label.set_color(linear_color)
+            ax.tick_params('y', colors=linear_color)
+
+            log_color = plot_details_dict.get('log_style', self._DEFAULT_HIST_STYLE).get('color', self._DEFAULT_HIST_STYLE['log_style']['color'])
+            ax.spines['right'].set_color(log_color)  # Actually belongs to ax and not ax2.
+            ax2.yaxis.label.set_color(log_color)
+            ax2.tick_params('y', colors=log_color)
+
             handles, labels = ax.get_legend_handles_labels()
             handles2, labels2 = ax2.get_legend_handles_labels()
             handles = handles + handles2

--- a/scripts/ta_dump.py
+++ b/scripts/ta_dump.py
@@ -354,6 +354,7 @@ def main():
                 'xticks': {
                         'labels': ALGORITHM_LABELS,
                         'ticks': ALGORITHM_TICKS,
+                        'fontsize': 6,
                         'rotation': 60,
                         'ha': 'right'  # Horizontal alignment
                     }
@@ -454,6 +455,7 @@ def main():
                 'xticks': {
                         'labels': TYPE_LABELS,
                         'ticks': TYPE_TICKS,
+                        'fontsize': 6,
                         'rotation': 60,
                         'ha': 'right'  # Horizontal alignment
                     }

--- a/scripts/ta_dump.py
+++ b/scripts/ta_dump.py
@@ -290,6 +290,11 @@ def main():
 
     data = trgtools.TAReader(filename, verbosity)
 
+    # Check that there are TA fragments.
+    if len(data.get_fragment_paths()) == 0:
+        print("File doesn't contain any TriggerActivity fragments.")
+        return 1
+
     # Load all case.
     if start_frag == 0 and end_frag == -1:
         data.read_all_fragments()  # Has extra debug/warning info

--- a/scripts/ta_dump.py
+++ b/scripts/ta_dump.py
@@ -344,7 +344,7 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'algorithm': {
-                'bins': np.arange(-0.5, np.max(ALGORITHM_TICKS) + 1, 1),
+                'bins': np.sort(np.array([(tick-0.45, tick+0.45) for tick in ALGORITHM_TICKS]).flatten()),
                 'title': "Algorithm Histogram",
                 'xlabel': 'Algorithm Type',
                 'ylabel': "Count",
@@ -445,7 +445,7 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'type': {
-                'bins': np.arange(-0.5, np.max(TYPE_TICKS) + 1, 1),
+                'bins': np.sort(np.array([(tick-0.45, tick+0.45) for tick in TYPE_TICKS]).flatten()),
                 'title': "Type Histogram",
                 'xlabel': "Type",
                 'ylabel': "Count",

--- a/scripts/ta_dump.py
+++ b/scripts/ta_dump.py
@@ -206,7 +206,7 @@ def parse():
     Parses CLI input arguments.
     """
     parser = argparse.ArgumentParser(
-        description="Display diagnostic information for TAs for a given tpstream file."
+        description="Display diagnostic information for TAs for a given HDF5 file."
     )
     parser.add_argument(
         "filename",

--- a/scripts/tc_dump.py
+++ b/scripts/tc_dump.py
@@ -330,6 +330,7 @@ def main():
                 'xticks': {
                         'labels': ALGORITHM_LABELS,
                         'ticks': ALGORITHM_TICKS,
+                        'fontsize': 6,
                         'rotation': 60,
                         'ha': 'right'  # Horizontal alignment
                     }
@@ -399,6 +400,7 @@ def main():
                 'xticks': {
                         'labels': TYPE_LABELS,
                         'ticks': TYPE_TICKS,
+                        'fontsize': 6,
                         'rotation': 60,
                         'ha': 'right'  # Horizontal alignment
                     }

--- a/scripts/tc_dump.py
+++ b/scripts/tc_dump.py
@@ -205,7 +205,7 @@ def parse():
     Parses CLI input arguments.
     """
     parser = argparse.ArgumentParser(
-        description="Display diagnostic information for TCs for a given tpstream file."
+        description="Display diagnostic information for TCs for a given HDF5 file."
     )
     parser.add_argument(
         "filename",

--- a/scripts/tc_dump.py
+++ b/scripts/tc_dump.py
@@ -283,6 +283,11 @@ def main():
 
     data = trgtools.TCReader(filename, verbosity)
 
+    # Check that there are TC fragments.
+    if len(data.get_fragment_paths()) == 0:
+        print("File doesn't contain any TriggerCandidate fragments.")
+        return 1
+
     # Load all case.
     if start_frag == 0 and end_frag == -1:
         data.read_all_fragments()  # Has extra debug/warning info

--- a/scripts/tc_dump.py
+++ b/scripts/tc_dump.py
@@ -320,7 +320,7 @@ def main():
     # Dictionary containing unique title, xlabel, and xticks (only some)
     plot_hist_dict = {
             'algorithm': {
-                'bins': np.arange(-0.5, np.max(ALGORITHM_TICKS) + 1, 1),
+                'bins': np.sort(np.array([(tick-0.45, tick+0.45) for tick in ALGORITHM_TICKS]).flatten()),
                 'title': "Algorithm",
                 'xlabel': 'Algorithm Type',
                 'ylabel': "Count",
@@ -390,7 +390,7 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'type': {
-                'bins': np.arange(-0.5, np.max(TYPE_TICKS) + 1, 1),
+                'bins': np.sort(np.array([(tick-0.45, tick+0.45) for tick in TYPE_TICKS]).flatten()),
                 'title': "Type",
                 'xlabel': "Type",
                 'ylabel': "Count",

--- a/scripts/tp_dump.py
+++ b/scripts/tp_dump.py
@@ -313,6 +313,7 @@ def main():
                 'xticks': {
                         'labels': ALGORITHM_LABELS,
                         'ticks': ALGORITHM_TICKS,
+                        'fontsize': 6,
                         'rotation': 60,
                         'ha': 'right'  # Horizontal alignment
                     }
@@ -386,6 +387,7 @@ def main():
                 'xticks': {
                         'labels': TYPE_LABELS,
                         'ticks': TYPE_TICKS,
+                        'fontsize': 6,
                         'rotation': 60,
                         'ha': 'right'  # Horizontal alignment
                     }

--- a/scripts/tp_dump.py
+++ b/scripts/tp_dump.py
@@ -248,6 +248,11 @@ def main():
 
     data = trgtools.TPReader(filename, verbosity)
 
+    # Check that there are TP fragments.
+    if len(data.get_fragment_paths()) == 0:
+        print("File doesn't contain any TriggerPrimitive fragments.")
+        return 1
+
     # Load all case
     if start_frag == 0 and end_frag == -1:
         data.read_all_fragments()  # Has extra debug/warning info

--- a/scripts/tp_dump.py
+++ b/scripts/tp_dump.py
@@ -184,7 +184,7 @@ def write_summary_stats(data: np.ndarray, filename: str, title: str) -> None:
 
 def parse():
     parser = argparse.ArgumentParser(
-        description="Display diagnostic information for TAs for a given tpstream file."
+        description="Display diagnostic information for TPs for a given HDF5 file."
     )
     parser.add_argument(
         "filename",

--- a/scripts/tp_dump.py
+++ b/scripts/tp_dump.py
@@ -303,7 +303,7 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'algorithm': {
-                'bins': np.arange(-0.5, np.max(ALGORITHM_TICKS) + 1, 1),
+                'bins': np.sort(np.array([(tick-0.45, tick+0.45) for tick in ALGORITHM_TICKS]).flatten()),
                 'title': "Algorithm Histogram",
                 'xlabel': 'Algorithm Type',
                 'ylabel': "Count",
@@ -377,7 +377,7 @@ def main():
                 'log_style': dict(color='#EE442F', alpha=0.6, label='Log')
             },
             'type': {
-                'bins': np.arange(-0.5, np.max(TYPE_TICKS) + 1, 1),
+                'bins': np.sort(np.array([(tick-0.45, tick+0.45) for tick in TYPE_TICKS]).flatten()),
                 'title': "Type Histogram",
                 'xlabel': "Type",
                 'ylabel': "Count",

--- a/scripts/tp_dump.py
+++ b/scripts/tp_dump.py
@@ -100,15 +100,20 @@ def plot_pdf_adc_integral_vs_peak(tp_data: np.ndarray, pdf: PdfPages, verbosity:
         )
         print("Total number of TPs:", len(tp_data['adc_peak']))
     high_integral_locs = np.where(tp_data['adc_integral'] == np.power(2, 15)-1)
+    unity = (np.min(tp_data['adc_peak']), np.max(tp_data['adc_peak']))
 
     plt.figure(figsize=(6, 4), dpi=200)
 
-    plt.scatter(
+    plt.plot(
         tp_data['adc_peak'],
         tp_data['adc_integral'],
-        c='k',
-        s=2,
+        c="#00000055",
+        ms=2,
+        ls='none',
+        marker='o',
+        mew=0,
         label='TP',
+        zorder=2,
         rasterized=True
     )
     plt.scatter(
@@ -117,7 +122,16 @@ def plot_pdf_adc_integral_vs_peak(tp_data: np.ndarray, pdf: PdfPages, verbosity:
         c='#63ACBE',
         s=2, marker='+',
         label=r'$2^{15}-1$',
+        zorder=3,
         rasterized=True
+    )
+    plt.plot(
+        unity,
+        unity,
+        color='#EE442F',
+        label="Unity",
+        lw=2,
+        zorder=1
     )
 
     plt.title("ADC Integral vs ADC Peak")


### PR DESCRIPTION
This is the result of a few plotting style requests. The only functionality change is an empty TriggerX guard, i.e., if the file does not have `TriggerActivity` fragments, print that it's empty and do nothing.

## Updated Axis Colors
Axes on the linear and logarithmic plots are now the same color as the plot contents.

![new_axis_coloring](https://github.com/DUNE-DAQ/trgtools/assets/5084895/83e32eee-13fe-47e9-8642-578cb336fc1a)

## Updated Algorithm & Type Histograms Separation
Increased the separation between bins in both histograms and decreased the font size for the x-label names.

![new_hist_separation](https://github.com/DUNE-DAQ/trgtools/assets/5084895/972641bf-7cf9-40da-91a9-4787d999872f)

## Updated TP ADC Integral vs ADC Peak
Added a line of unity for visualization and made the markers transparent to better view their distribution.

![new_adc_integral_vs_peak](https://github.com/DUNE-DAQ/trgtools/assets/5084895/9f8c5e44-5250-4bbe-91fd-40acf3b33815)

## Testing
```bash
tp_dump.py <HDF5>
tc_dump.py <HDF5>
ta_dump.py <HDF5>
```
Simply notice the above features in the plots and the warning for HDF5s that do not contain TP/TA/TC fragments.