### PR TITLE
Emulation refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ daq_add_python_bindings(*.cpp LINK_LIBRARIES ${PROJECT_NAME} ) # Any additional 
 daq_add_application(trgtools_tapipe tapipe.cxx LINK_LIBRARIES ${PROJECT_NAME})
 daq_add_application(trgtools_copy_tpstream copy_tpstream.cxx LINK_LIBRARIES ${PROJECT_NAME})
 daq_add_application(trgtools_process_tpstream process_tpstream.cxx LINK_LIBRARIES ${PROJECT_NAME})
+daq_add_application(trgtools_emulate_from_tpstream emulate_from_tpstream.cxx LINK_LIBRARIES ${PROJECT_NAME})
 
 ##############################################################################
 

--- a/apps/emulate_from_tpstream.cxx
+++ b/apps/emulate_from_tpstream.cxx
@@ -26,20 +26,30 @@ using namespace dunedaq;
 using namespace trgtools;
 
 /**
- * @brief Saves fragments in timeslices
+ * @brief Saves fragments in timeslice format into output HDF5 file
+ *
+ * @param _outputfilename Name of the hdf5 file to save the output into
+ * @param _sourceid_geoid_map sourceid--geoid map required to create a HDF5 file
+ * @param _frags Map of fragments, with a vector of fragment pointers for each slice id
+ * @param _quiet Do we want to quiet down the cout?
  */
 void SaveFragments(const std::string& _outputfilename,
-                      const hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t& _sourceid_geoid_map,
-                      std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> _frags)
+                   const hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t& _sourceid_geoid_map,
+                   std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> _frags,
+                   bool _quiet)
 {
+  // Create layout parameter object required for HDF5 creation
   hdf5libs::HDF5FileLayoutParameters layout_params;
 
+  // Create HDF5 parameter path required for the layout
   hdf5libs::HDF5PathParameters params_trigger;
   params_trigger.detector_group_type = "Detector_Readout";
+  /// @todo Maybe in the future we will want to emulate PDS TPs. 
   params_trigger.detector_group_name = "TPC";
   params_trigger.element_name_prefix = "Link";
   params_trigger.digits_for_element_number = 5;
 
+  // Fill the HDF5 layout
   std::vector<hdf5libs::HDF5PathParameters> params;
   params.push_back(params_trigger);
   layout_params.record_name_prefix = "TimeSlice";
@@ -50,6 +60,7 @@ void SaveFragments(const std::string& _outputfilename,
   layout_params.view_group_name = "Views";
   layout_params.path_params_list = {params};
 
+  // Create pointer to a new output HDF5 file
   std::unique_ptr<hdf5libs::HDF5RawDataFile> output_file = std::make_unique<hdf5libs::HDF5RawDataFile>(
       _outputfilename + ".hdf5",
       _frags.begin()->second[0]->get_run_number(),
@@ -58,18 +69,28 @@ void SaveFragments(const std::string& _outputfilename,
       layout_params,
       _sourceid_geoid_map);
 
+  // Iterate over the time slices & save all the fragments
   for (auto& [slice_id, vec_frags]: _frags) {
+    // Create a new timeslice header
     daqdataformats::TimeSliceHeader tsh;
     tsh.timeslice_number = slice_id;
     tsh.run_number = vec_frags[0]->get_run_number();
     tsh.element_id = dunedaq::daqdataformats::SourceID(dunedaq::daqdataformats::SourceID::Subsystem::kTRBuilder, 0);
 
+    // Create a new timeslice
     dunedaq::daqdataformats::TimeSlice ts(tsh);
-    std::cout << "Time slice number: " << slice_id << std::endl;
+    if (!_quiet) {
+      std::cout << "Time slice number: " << slice_id << std::endl;
+    }
+    // Add the fragments to the timeslices
     for (std::unique_ptr<daqdataformats::Fragment>& frag_ptr: vec_frags) {
-      std::cout << "  Writing elementid: " << frag_ptr->get_element_id()  << " trigger number: " << frag_ptr->get_trigger_number() << " trigger_timestamp: " << frag_ptr->get_trigger_timestamp() << " window_begin: " << frag_ptr->get_window_begin() << " sequence_no: " << frag_ptr->get_sequence_number() << std::endl;
+      if (!_quiet) {
+        std::cout << "  Writing elementid: " << frag_ptr->get_element_id()  << " trigger number: " << frag_ptr->get_trigger_number() << " trigger_timestamp: " << frag_ptr->get_trigger_timestamp() << " window_begin: " << frag_ptr->get_window_begin() << " sequence_no: " << frag_ptr->get_sequence_number() << std::endl;
+      }
       ts.add_fragment(std::move(frag_ptr));
     }
+
+    // Write the timeslice to output file
     output_file->write(ts);
   }
 }
@@ -88,7 +109,6 @@ SortFilesPerWriter(const std::vector<std::string>& _files)
   for (const std::string& file : _files) {
     std::shared_ptr<hdf5libs::HDF5RawDataFile> fl = std::make_shared<hdf5libs::HDF5RawDataFile>(file);
     if (!fl->is_timeslice_type()) {
-      fmt::print("ERROR: input file '{}' not of type 'TimeSlice'\n", file);
       throw std::runtime_error(fmt::format("ERROR: input file '{}' not of type 'TimeSlice'", file));
     }
 
@@ -125,43 +145,63 @@ SortFilesPerWriter(const std::vector<std::string>& _files)
  * @todo: Rather than returning the sliceID range, should try to return a time range -- and have processors go off that.
  *
  * @param _files: a map of writer app names & vectors of HDF5 files from that application.
+ * @param _quiet Do we want to quiet down the cout?
  */
 std::pair<uint64_t, uint64_t>
-GetAvailableSliceIDRange(const std::map<std::string, std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>>> _files)
+GetAvailableSliceIDRange(const std::map<std::string, std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>>>& _files,
+                         bool _quiet)
 {
+  if (_files.empty()) {
+    throw std::runtime_error("No files provided");
+  }
+
   uint64_t global_start = std::numeric_limits<uint64_t>::min();
   uint64_t global_end = std::numeric_limits<uint64_t>::max();
 
-  // Get the min-max per app
-  std::map<std::string, std::pair<uint64_t, uint64_t>> app_slice_map;
+  // Get the min & max record id per application, and the global
   for (auto& [appid, vec_files]: _files) {
     uint64_t app_start = std::numeric_limits<uint64_t>::max();
     uint64_t app_end = std::numeric_limits<uint64_t>::min();
 
+    // Find min / max record id for this application
     for (auto& file : vec_files) {
       auto record_ids = file->get_all_record_ids();
+      if (record_ids.empty()) {
+        throw std::runtime_error(fmt::format("File from application {} contains no records.", appid));
+      }
       app_start = std::min(app_start, record_ids.begin()->first);
       app_end = std::max(app_end, record_ids.rbegin()->first);
     }
 
-    app_slice_map[appid] = std::make_pair(app_start, app_end);
-
+    // Update the global min / max record id
     global_start = std::max(global_start, app_start);
     global_end = std::min(global_end, app_end);
-    std::cout << "Application: " << appid << " " << " TimeSliceID start: " << app_start << " end: " << app_end << std::endl;
+
+    if (!_quiet) {
+      std::cout << "Application: " << appid << " " << " TimeSliceID start: " << app_start << " end: " << app_end << std::endl;
+    }
   }
 
-  std::cout << "Global start: " << global_start << " Global end: " << global_end << std::endl;
+  if (!_quiet) {
+    std::cout << "Global start: " << global_start << " Global end: " << global_end << std::endl;
+  }
   if (global_start > global_end) {
     throw std::runtime_error("One of the provided files' id range did not overlap with the rest. Please select files with overlapping TimeSlice IDs");
   }
 
+  // Extra validation / error handling
   for (auto& [appid, vec_files]: _files) {
     for (auto& file : vec_files) {
       auto record_ids = file->get_all_record_ids();
-      if ((record_ids.begin()->first > global_end || record_ids.rbegin()->first < global_start)) {
+
+      uint64_t file_start = record_ids.begin()->first;
+      uint64_t file_end = record_ids.rbegin()->first;
+      if ((file_start > global_end || file_end < global_start)) {
         uint64_t file_index = file->get_attribute<size_t>("file_index");
-        throw std::runtime_error(fmt::format("File from TPStreamWrite application: {} with index: {} does not overlap with any other applications' TimeSlice IDs.", appid, file_index));
+        throw std::runtime_error(fmt::format(
+          "File from TPStreamWrite application '{}' (index '{}') has record id range [{}, {}], which does not overlap with global range [{}, {}].",
+           appid, file_index, file_start, file_end, global_start, global_end
+          ));
       }
     }
   }
@@ -169,38 +209,59 @@ GetAvailableSliceIDRange(const std::map<std::string, std::vector<std::shared_ptr
   return {global_start, global_end};
 }
 
-int main(int argc, char const *argv[])
+/**
+ * @brief Struct with available cli application options
+ */
+struct Options
 {
-  // Do all the CLI processing first
-  CLI::App app{"Trigger TA & TC emulatior"};
-
+  /// @brief vector of input filenames
   std::vector<std::string> input_files;
-  app.add_option("-i,--input-files", input_files, "List of input files (required)")
+  /// @brief output filename
+  std::string output_filename;
+  /// @brief the configuration filename
+  std::string config_name;
+  /// @brief do we want to quiet down the cout? Default: no
+  bool quiet = false;
+  /// @brief do we want to measure latencies? Default: no
+  /// @todo: Latencies currently not supported!
+  bool latencies = false;
+};
+
+/**
+ * @brief Adds options to our CLI application
+ * 
+ * @param _app CLI application
+ * @param _opts Struct with the available options
+ */
+void ParseApp(CLI::App& _app, Options& _opts)
+{
+  _app.add_option("-i,--input-files", _opts.input_files, "List of input files (required)")
     ->required()
     ->check(CLI::ExistingFile); // Validate that each file exists
 
   std::string output_filename;
-  app.add_option("-o,--output-file", output_filename, "Output file (required)")
+  _app.add_option("-o,--output-file", _opts.output_filename, "Output file (required)")
     ->required(); // make the argument required
 
-  // Default 0, meaning process everything
-  uint64_t milliseconds_to_process = 0;
-  app.add_option("-m,--milliseconds", milliseconds_to_process, "Number of milliseconds to process");
-
-  std::string channel_map_name = "VDColdboxChannelMap";
-  app.add_option("-c,--channel-map", channel_map_name, "Detector Channel Map")
-    ->check(CLI::ExistingFile);
-
   std::string config_name;
-  app.add_option("-j,--json-config", config_name, "Trigger Activity and Candidate config JSON to use.")
+  _app.add_option("-j,--json-config", _opts.config_name, "Trigger Activity and Candidate config JSON to use (required)")
     ->required()
     ->check(CLI::ExistingFile);
 
   bool quiet = false;
-  app.add_flag("--quiet", quiet, "Quiet outputs.");
+  _app.add_flag("--quiet", _opts.quiet, "Quiet outputs.");
 
   bool latencies = false;
-  app.add_flag("--latencies", latencies, "Saves latencies per TP into csv");
+  _app.add_flag("--latencies", _opts.latencies, "Saves latencies per TP into csv");
+}
+
+int main(int argc, char const *argv[])
+{
+  // Do all the CLI processing first
+  CLI::App app{"Offline trigger TriggerActivity & TriggerCandidate emulatior"};
+  Options opts{};
+
+  ParseApp(app, opts);
 
   try {
     app.parse(argc, argv);
@@ -208,28 +269,34 @@ int main(int argc, char const *argv[])
   catch (const CLI::ParseError &e) {
     return app.exit(e);
   }
-  std::ifstream config_stream(config_name);
+
+  // Get the configuration file
+  std::ifstream config_stream(opts.config_name);
   nlohmann::json config = nlohmann::json::parse(config_stream);
 
-  std::cout << "Files to process:\n";
-  for (const std::string& file : input_files) {
-    std::cout << "- " << file << "\n";
+  if (!opts.quiet) {
+    std::cout << "Files to process:\n";
+    for (const std::string& file : opts.input_files) {
+      std::cout << "- " << file << "\n";
+    }
   }
 
+  // Sort the files into a map writer_id::vector<HDF5>
   std::map<std::string, std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>>> sorted_files =
-    SortFilesPerWriter(input_files);
+    SortFilesPerWriter(opts.input_files);
 
-  std::pair<uint64_t, uint64_t> recordid_range = GetAvailableSliceIDRange(sorted_files);
+  // Get the available record_id range
+  std::pair<uint64_t, uint64_t> recordid_range = GetAvailableSliceIDRange(sorted_files, opts.quiet);
 
   // Create the file handlers
   std::vector<std::unique_ptr<TAFileHandler>> file_handlers;
-  for (const std::string& file : input_files) {
+  for (const std::string& file : opts.input_files) {
     file_handlers.push_back(std::make_unique<TAFileHandler>(file, config, recordid_range));
   }
 
   // Start each file handler
   for (const auto& handler : file_handlers) {
-    handler->start_processing(0, quiet);
+    handler->start_processing(0, opts.quiet);
   }
 
   // Output map of TA vectors & function that appends TAs to that vector
@@ -283,9 +350,10 @@ int main(int argc, char const *argv[])
         });
     n_tas += vec_tas.size();
   }
-  std::cout << "Total number of TAs made: " << n_tas << std::endl;
-
-  std::cout << "Creating TCMaker" << std::endl;
+  if (!opts.quiet) {
+    std::cout << "Total number of TAs made: " << n_tas << std::endl;
+    std::cout << "Creating a TCMaker..." << std::endl;
+  }
   // Create the TC emulator
   std::string algo_name = config["trigger_candidate_plugin"][0];
   nlohmann::json algo_config = config["trigger_candidate_config"][0];
@@ -297,7 +365,7 @@ int main(int argc, char const *argv[])
   trgtools::EmulateTCUnit tc_emulator;
   tc_emulator.set_maker(tc_maker);
 
-  // Emulate the TCs
+  // Emulate the TriggerCandidates
   std::vector<triggeralgs::TriggerCandidate> tcs;
   for (auto& [sliceid, vec_tas]: tas) {
     std::unique_ptr<daqdataformats::Fragment> tc_frag = tc_emulator.emulate_vector(vec_tas);
@@ -322,9 +390,11 @@ int main(int argc, char const *argv[])
     tcs.reserve(tcs.size() + tmp_tcs.size());
     tcs.insert(tcs.end(), std::make_move_iterator(tmp_tcs.begin()), std::make_move_iterator(tmp_tcs.end()));
   }
-  std::cout << "Total number of TCs made: " << tcs.size() << std::endl;
+  if (!opts.quiet) {
+    std::cout << "Total number of TCs made: " << tcs.size() << std::endl;
+  }
 
-  SaveFragments(output_filename, sourceid_geoid_map, std::move(frags));
+  SaveFragments(opts.output_filename, sourceid_geoid_map, std::move(frags), opts.quiet);
 
   return 0;
 }

--- a/apps/emulate_from_tpstream.cxx
+++ b/apps/emulate_from_tpstream.cxx
@@ -1,4 +1,3 @@
-#include "trgtools/EmulateTAUnit.hpp"
 #include "trgtools/EmulateTCUnit.hpp"
 #include "trgtools/TAFileHandler.hpp"
 
@@ -14,11 +13,7 @@
 #include "hdf5libs/HDF5RawDataFile.hpp"
 #include "hdf5libs/HDF5SourceIDHandler.hpp"
 
-#include "trgdataformats/TriggerPrimitive.hpp"
-#include "triggeralgs/TriggerActivityFactory.hpp"
 #include "triggeralgs/TriggerCandidateFactory.hpp"
-#include "triggeralgs/TriggerObjectOverlay.hpp"
-#include "detchannelmaps/TPCChannelMap.hpp"
 
 //-----------------------------------------------------------------------------
 

--- a/apps/emulate_from_tpstream.cxx
+++ b/apps/emulate_from_tpstream.cxx
@@ -224,6 +224,8 @@ struct Options
   /// @brief do we want to measure latencies? Default: no
   /// @todo: Latencies currently not supported!
   bool latencies = false;
+  /// @brief runs each TAMaker on a separate thread
+  bool run_parallel = false;
 };
 
 /**
@@ -238,19 +240,17 @@ void ParseApp(CLI::App& _app, Options& _opts)
     ->required()
     ->check(CLI::ExistingFile); // Validate that each file exists
 
-  std::string output_filename;
   _app.add_option("-o,--output-file", _opts.output_filename, "Output file (required)")
     ->required(); // make the argument required
 
-  std::string config_name;
   _app.add_option("-j,--json-config", _opts.config_name, "Trigger Activity and Candidate config JSON to use (required)")
     ->required()
     ->check(CLI::ExistingFile);
+  
+  _app.add_option("-p,--run-parallel", _opts.run_parallel, "Do you want to run in parallel (default: false)");
 
-  bool quiet = false;
   _app.add_flag("--quiet", _opts.quiet, "Quiet outputs.");
 
-  bool latencies = false;
   _app.add_flag("--latencies", _opts.latencies, "Saves latencies per TP into csv");
 }
 
@@ -290,12 +290,12 @@ int main(int argc, char const *argv[])
   // Create the file handlers
   std::vector<std::unique_ptr<TAFileHandler>> file_handlers;
   for (const std::string& file : opts.input_files) {
-    file_handlers.push_back(std::make_unique<TAFileHandler>(file, config, recordid_range));
+    file_handlers.push_back(std::make_unique<TAFileHandler>(file, config, recordid_range, opts.run_parallel, opts.quiet));
   }
 
   // Start each file handler
   for (const auto& handler : file_handlers) {
-    handler->start_processing(0, opts.quiet);
+    handler->start_processing();
   }
 
   // Output map of TA vectors & function that appends TAs to that vector

--- a/apps/emulate_from_tpstream.cxx
+++ b/apps/emulate_from_tpstream.cxx
@@ -12,6 +12,8 @@
 #include <filesystem>
 
 #include "hdf5libs/HDF5RawDataFile.hpp"
+#include "hdf5libs/HDF5SourceIDHandler.hpp"
+
 #include "trgdataformats/TriggerPrimitive.hpp"
 #include "triggeralgs/TriggerActivityFactory.hpp"
 #include "triggeralgs/TriggerCandidateFactory.hpp"
@@ -23,9 +25,152 @@
 using namespace dunedaq;
 using namespace trgtools;
 
+/**
+ * @brief Saves fragments in timeslices
+ */
+void SaveFragments(const std::string& _outputfilename,
+                      const hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t& _sourceid_geoid_map,
+                      std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> _frags)
+{
+  hdf5libs::HDF5FileLayoutParameters layout_params;
+
+  hdf5libs::HDF5PathParameters params_trigger;
+  params_trigger.detector_group_type = "Detector_Readout";
+  params_trigger.detector_group_name = "TPC";
+  params_trigger.element_name_prefix = "Link";
+  params_trigger.digits_for_element_number = 5;
+
+  std::vector<hdf5libs::HDF5PathParameters> params;
+  params.push_back(params_trigger);
+  layout_params.record_name_prefix = "TimeSlice";
+  layout_params.digits_for_record_number = 6;
+  layout_params.digits_for_sequence_number = 0;
+  layout_params.record_header_dataset_name = "TimeSliceHeader";
+  layout_params.raw_data_group_name = "RawData";
+  layout_params.view_group_name = "Views";
+  layout_params.path_params_list = {params};
+
+  std::unique_ptr<hdf5libs::HDF5RawDataFile> output_file = std::make_unique<hdf5libs::HDF5RawDataFile>(
+      _outputfilename + ".hdf5",
+      _frags.begin()->second[0]->get_run_number(),
+      0,
+      "emulate_from_tpstream",
+      layout_params,
+      _sourceid_geoid_map);
+
+  for (auto& [slice_id, vec_frags]: _frags) {
+    daqdataformats::TimeSliceHeader tsh;
+    tsh.timeslice_number = slice_id;
+    tsh.run_number = vec_frags[0]->get_run_number();
+    tsh.element_id = dunedaq::daqdataformats::SourceID(dunedaq::daqdataformats::SourceID::Subsystem::kTRBuilder, 0);
+
+    dunedaq::daqdataformats::TimeSlice ts(tsh);
+    std::cout << "Time slice number: " << slice_id << std::endl;
+    for (std::unique_ptr<daqdataformats::Fragment>& frag_ptr: vec_frags) {
+      std::cout << "  Writing elementid: " << frag_ptr->get_element_id()  << " trigger number: " << frag_ptr->get_trigger_number() << " trigger_timestamp: " << frag_ptr->get_trigger_timestamp() << " window_begin: " << frag_ptr->get_window_begin() << " sequence_no: " << frag_ptr->get_sequence_number() << std::endl;
+      ts.add_fragment(std::move(frag_ptr));
+    }
+    output_file->write(ts);
+  }
+}
+
+/**
+ * @brief Returns sorted map of HDF5 files per datawriter application
+ *
+ * @param _files: vector of strings corresponding to the input file paths
+ */
+std::map<std::string, std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>>>
+SortFilesPerWriter(const std::vector<std::string>& _files)
+{
+  std::map<std::string, std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>>> files_sorted;
+
+  // Put files into per-writer app groups
+  for (const std::string& file : _files) {
+    std::shared_ptr<hdf5libs::HDF5RawDataFile> fl = std::make_shared<hdf5libs::HDF5RawDataFile>(file);
+    if (!fl->is_timeslice_type()) {
+      fmt::print("ERROR: input file '{}' not of type 'TimeSlice'\n", file);
+      throw std::runtime_error(fmt::format("ERROR: input file '{}' not of type 'TimeSlice'", file));
+    }
+
+    std::string application_name = fl->get_attribute<std::string>("application_name");
+    files_sorted[application_name].push_back(fl);
+  }
+
+  // Sort files for each writer application individually
+  for (auto& [app_name, vec_files]: files_sorted) {
+    // Don't sort if we have 0 or 1 files in the application...
+    if (vec_files.size() <= 1) {
+      continue;
+    }
+
+    // Sort w.r.t. file index attribute
+    std::sort(vec_files.begin(), vec_files.end(),
+        [](const std::shared_ptr<hdf5libs::HDF5RawDataFile>& a, const std::shared_ptr<hdf5libs::HDF5RawDataFile>& b) {
+        return a->get_attribute<size_t>("file_index") <
+               b->get_attribute<size_t>("file_index");
+        });
+  }
+
+  return files_sorted;
+};
+
+/**
+ * @brief Retreives the available slice ID range
+ *
+ * Finds the overlap in the slice ID range between the provided files, and
+ * returns that overlap as an available range -- or crashes if there is a file
+ * with a range that does not overlap.
+ *
+ * @todo: Allow a case where we have multiple writer apps, multiple files per writer app, but one file outside of the overlap.
+ * @todo: Rather than returning the sliceID range, should try to return a time range -- and have processors go off that.
+ *
+ * @param _files: a map of writer app names & vectors of HDF5 files from that application.
+ */
+std::pair<uint64_t, uint64_t>
+GetAvailableSliceIDRange(const std::map<std::string, std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>>> _files)
+{
+  uint64_t global_start = std::numeric_limits<uint64_t>::min();
+  uint64_t global_end = std::numeric_limits<uint64_t>::max();
+
+  // Get the min-max per app
+  std::map<std::string, std::pair<uint64_t, uint64_t>> app_slice_map;
+  for (auto& [appid, vec_files]: _files) {
+    uint64_t app_start = std::numeric_limits<uint64_t>::max();
+    uint64_t app_end = std::numeric_limits<uint64_t>::min();
+
+    for (auto& file : vec_files) {
+      auto record_ids = file->get_all_record_ids();
+      app_start = std::min(app_start, record_ids.begin()->first);
+      app_end = std::max(app_end, record_ids.rbegin()->first);
+    }
+
+    app_slice_map[appid] = std::make_pair(app_start, app_end);
+
+    global_start = std::max(global_start, app_start);
+    global_end = std::min(global_end, app_end);
+    std::cout << "Application: " << appid << " " << " TimeSliceID start: " << app_start << " end: " << app_end << std::endl;
+  }
+
+  std::cout << "Global start: " << global_start << " Global end: " << global_end << std::endl;
+  if (global_start > global_end) {
+    throw std::runtime_error("One of the provided files' id range did not overlap with the rest. Please select files with overlapping TimeSlice IDs");
+  }
+
+  for (auto& [appid, vec_files]: _files) {
+    for (auto& file : vec_files) {
+      auto record_ids = file->get_all_record_ids();
+      if ((record_ids.begin()->first > global_end || record_ids.rbegin()->first < global_start)) {
+        uint64_t file_index = file->get_attribute<size_t>("file_index");
+        throw std::runtime_error(fmt::format("File from TPStreamWrite application: {} with index: {} does not overlap with any other applications' TimeSlice IDs.", appid, file_index));
+      }
+    }
+  }
+
+  return {global_start, global_end};
+}
+
 int main(int argc, char const *argv[])
 {
-
   // Do all the CLI processing first
   CLI::App app{"Trigger TA & TC emulatior"};
 
@@ -34,8 +179,8 @@ int main(int argc, char const *argv[])
     ->required()
     ->check(CLI::ExistingFile); // Validate that each file exists
 
-  std::string output_file;
-  app.add_option("-o,--output-file", output_file, "Output file (required)")
+  std::string output_filename;
+  app.add_option("-o,--output-file", output_filename, "Output file (required)")
     ->required(); // make the argument required
 
   // Default 0, meaning process everything
@@ -50,12 +195,6 @@ int main(int argc, char const *argv[])
   app.add_option("-j,--json-config", config_name, "Trigger Activity and Candidate config JSON to use.")
     ->required()
     ->check(CLI::ExistingFile);
-
-  size_t worker_threads = 0;
-  app.add_option("-w,--worker-threads", worker_threads, "Number of worker threads to spawn (default=0, nthreads = nplanes)");
-
-  bool ram_efficient = 0;
-  app.add_option("-r,--ram-efficient", ram_efficient, "RAM-efficient mode (but slower)");
 
   bool quiet = false;
   app.add_flag("--quiet", quiet, "Quiet outputs.");
@@ -77,24 +216,115 @@ int main(int argc, char const *argv[])
     std::cout << "- " << file << "\n";
   }
 
+  std::map<std::string, std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>>> sorted_files =
+    SortFilesPerWriter(input_files);
+
+  std::pair<uint64_t, uint64_t> recordid_range = GetAvailableSliceIDRange(sorted_files);
+
   // Create the file handlers
   std::vector<std::unique_ptr<TAFileHandler>> file_handlers;
   for (const std::string& file : input_files) {
-    file_handlers.push_back(std::make_unique<TAFileHandler>(file, config, worker_threads));
+    file_handlers.push_back(std::make_unique<TAFileHandler>(file, config, recordid_range));
   }
 
   // Start each file handler
   for (const auto& handler : file_handlers) {
-    handler->start_processing();
+    handler->start_processing(0, quiet);
   }
 
+  // Output map of TA vectors & function that appends TAs to that vector
+  std::map<uint64_t, std::vector<triggeralgs::TriggerActivity>> tas;
+  auto append_tas = [&tas](std::map<uint64_t, std::vector<triggeralgs::TriggerActivity>>&& _tas) {
+    for (auto& [sliceid, src_vec] : _tas) {
+      auto& dest_vec = tas[sliceid];
+      dest_vec.reserve(dest_vec.size() + src_vec.size());
+
+      dest_vec.insert(dest_vec.end(), std::make_move_iterator(src_vec.begin()), std::make_move_iterator(src_vec.end()));
+      src_vec.clear();
+    }
+  };
+
+  // Output map of Fragment vectors & function that appends TAs to that vector
+  std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> frags;
+  auto append_frags = [&frags](std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>>&& _frags) {
+    for (auto& [sliceid, src_vec] : _frags) {
+      auto& dest_vec = frags[sliceid];
+
+      dest_vec.reserve(dest_vec.size() + src_vec.size());
+
+      dest_vec.insert(dest_vec.end(), std::make_move_iterator(src_vec.begin()), std::make_move_iterator(src_vec.end()));
+      src_vec.clear();
+    }
+  };
+
+  // Iterate over the handlers, wait for them to complete their job & append
+  // their TAs to our vector when ready.
+  hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t sourceid_geoid_map;
   for (const auto& handler : file_handlers) {
+    // Wait for all TAs to be made
     handler->wait_to_complete_work();
+
+    // Append output TA/fragments
+    append_tas(std::move(handler->get_tas()));
+    append_frags(std::move(handler->get_frags()));
+
+    // Get and merge the source ID map
+    hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t map = handler->get_sourceid_geoid_map();
+    sourceid_geoid_map.insert(map.begin(), map.end());
   }
-  std::cout << "All threads joined" << std::endl;
 
+  // Sort the TAs in each slice before pushing them into the TCMaker
+  size_t n_tas = 0;
+  for (auto& [sliceid, vec_tas]: tas) {
+    std::sort(vec_tas.begin(), vec_tas.end(),
+        [](const triggeralgs::TriggerActivity& a, const triggeralgs::TriggerActivity& b) {
+        return std::tie(a.time_start, a.channel_start, a.time_end) <
+               std::tie(b.time_start, b.channel_start, b.time_end);
+        });
+    n_tas += vec_tas.size();
+  }
+  std::cout << "Total number of TAs made: " << n_tas << std::endl;
 
-  // Extract & sort all the TAs when ready
+  std::cout << "Creating TCMaker" << std::endl;
+  // Create the TC emulator
+  std::string algo_name = config["trigger_candidate_plugin"][0];
+  nlohmann::json algo_config = config["trigger_candidate_config"][0];
+
+  std::unique_ptr<triggeralgs::TriggerCandidateMaker> tc_maker =
+    triggeralgs::TriggerCandidateFactory::get_instance()->build_maker(algo_name);
+  tc_maker->configure(algo_config);
+
+  trgtools::EmulateTCUnit tc_emulator;
+  tc_emulator.set_maker(tc_maker);
+
+  // Emulate the TCs
+  std::vector<triggeralgs::TriggerCandidate> tcs;
+  for (auto& [sliceid, vec_tas]: tas) {
+    std::unique_ptr<daqdataformats::Fragment> tc_frag = tc_emulator.emulate_vector(vec_tas);
+    if (!tc_frag) {
+      continue;
+    }
+
+    // Manipulate the fragment header
+    daqdataformats::FragmentHeader frag_hdr = tc_frag->get_header();
+    frag_hdr.element_id = daqdataformats::SourceID{daqdataformats::SourceID::Subsystem::kTrigger, tc_frag->get_element_id().id+10000};
+
+    tc_frag->set_header_fields(frag_hdr);
+    tc_frag->set_type(daqdataformats::FragmentType::kTriggerCandidate);
+    tc_frag->set_trigger_number(sliceid);
+    tc_frag->set_window_begin(frags[sliceid][0]->get_window_begin());
+    tc_frag->set_window_end(frags[sliceid][0]->get_window_end());
+
+    // Push the fragment to our list
+    frags[sliceid].push_back(std::move(tc_frag));
+
+    std::vector<triggeralgs::TriggerCandidate> tmp_tcs = tc_emulator.get_last_output_buffer();
+    tcs.reserve(tcs.size() + tmp_tcs.size());
+    tcs.insert(tcs.end(), std::make_move_iterator(tmp_tcs.begin()), std::make_move_iterator(tmp_tcs.end()));
+  }
+  std::cout << "Total number of TCs made: " << tcs.size() << std::endl;
+
+  SaveFragments(output_filename, sourceid_geoid_map, std::move(frags));
 
   return 0;
 }

--- a/apps/emulate_from_tpstream.cxx
+++ b/apps/emulate_from_tpstream.cxx
@@ -141,7 +141,6 @@ SortFilesPerWriter(const std::vector<std::string>& _files)
  * returns that overlap as an available range -- or crashes if there is a file
  * with a range that does not overlap.
  *
- * @todo: Allow a case where we have multiple writer apps, multiple files per writer app, but one file outside of the overlap.
  * @todo: Rather than returning the sliceID range, should try to return a time range -- and have processors go off that.
  *
  * @param _files: a map of writer app names & vectors of HDF5 files from that application.

--- a/apps/emulate_from_tpstream.cxx
+++ b/apps/emulate_from_tpstream.cxx
@@ -135,7 +135,7 @@ SortFilesPerWriter(const std::vector<std::string>& _files)
 };
 
 /**
- * @brief Retreives the available slice ID range
+ * @brief Retrieves the available slice ID range
  *
  * Finds the overlap in the slice ID range between the provided files, and
  * returns that overlap as an available range -- or crashes if there is a file

--- a/apps/emulate_from_tpstream.cxx
+++ b/apps/emulate_from_tpstream.cxx
@@ -247,7 +247,7 @@ void ParseApp(CLI::App& _app, Options& _opts)
     ->required()
     ->check(CLI::ExistingFile);
   
-  _app.add_option("-p,--run-parallel", _opts.run_parallel, "Do you want to run in parallel (default: false)");
+  _app.add_flag("--parallel", _opts.run_parallel, "Run the TAMakers in parallel");
 
   _app.add_flag("--quiet", _opts.quiet, "Quiet outputs.");
 
@@ -289,8 +289,8 @@ int main(int argc, char const *argv[])
 
   // Create the file handlers
   std::vector<std::unique_ptr<TAFileHandler>> file_handlers;
-  for (const std::string& file : opts.input_files) {
-    file_handlers.push_back(std::make_unique<TAFileHandler>(file, config, recordid_range, opts.run_parallel, opts.quiet));
+  for (auto [name, files] : sorted_files) {
+    file_handlers.push_back(std::make_unique<TAFileHandler>(files, config, recordid_range, opts.run_parallel, opts.quiet));
   }
 
   // Start each file handler

--- a/apps/emulate_from_tpstream.cxx
+++ b/apps/emulate_from_tpstream.cxx
@@ -1,0 +1,100 @@
+#include "trgtools/EmulateTAUnit.hpp"
+#include "trgtools/EmulateTCUnit.hpp"
+#include "trgtools/TAFileHandler.hpp"
+
+#include "CLI/App.hpp"
+#include "CLI/Config.hpp"
+#include "CLI/Formatter.hpp"
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/chrono.h>
+#include <filesystem>
+
+#include "hdf5libs/HDF5RawDataFile.hpp"
+#include "trgdataformats/TriggerPrimitive.hpp"
+#include "triggeralgs/TriggerActivityFactory.hpp"
+#include "triggeralgs/TriggerCandidateFactory.hpp"
+#include "triggeralgs/TriggerObjectOverlay.hpp"
+#include "detchannelmaps/TPCChannelMap.hpp"
+
+//-----------------------------------------------------------------------------
+
+using namespace dunedaq;
+using namespace trgtools;
+
+int main(int argc, char const *argv[])
+{
+
+  // Do all the CLI processing first
+  CLI::App app{"Trigger TA & TC emulatior"};
+
+  std::vector<std::string> input_files;
+  app.add_option("-i,--input-files", input_files, "List of input files (required)")
+    ->required()
+    ->check(CLI::ExistingFile); // Validate that each file exists
+
+  std::string output_file;
+  app.add_option("-o,--output-file", output_file, "Output file (required)")
+    ->required(); // make the argument required
+
+  // Default 0, meaning process everything
+  uint64_t milliseconds_to_process = 0;
+  app.add_option("-m,--milliseconds", milliseconds_to_process, "Number of milliseconds to process");
+
+  std::string channel_map_name = "VDColdboxChannelMap";
+  app.add_option("-c,--channel-map", channel_map_name, "Detector Channel Map")
+    ->check(CLI::ExistingFile);
+
+  std::string config_name;
+  app.add_option("-j,--json-config", config_name, "Trigger Activity and Candidate config JSON to use.")
+    ->required()
+    ->check(CLI::ExistingFile);
+
+  size_t worker_threads = 0;
+  app.add_option("-w,--worker-threads", worker_threads, "Number of worker threads to spawn (default=0, nthreads = nplanes)");
+
+  bool ram_efficient = 0;
+  app.add_option("-r,--ram-efficient", ram_efficient, "RAM-efficient mode (but slower)");
+
+  bool quiet = false;
+  app.add_flag("--quiet", quiet, "Quiet outputs.");
+
+  bool latencies = false;
+  app.add_flag("--latencies", latencies, "Saves latencies per TP into csv");
+
+  try {
+    app.parse(argc, argv);
+  }
+  catch (const CLI::ParseError &e) {
+    return app.exit(e);
+  }
+  std::ifstream config_stream(config_name);
+  nlohmann::json config = nlohmann::json::parse(config_stream);
+
+  std::cout << "Files to process:\n";
+  for (const std::string& file : input_files) {
+    std::cout << "- " << file << "\n";
+  }
+
+  // Create the file handlers
+  std::vector<std::unique_ptr<TAFileHandler>> file_handlers;
+  for (const std::string& file : input_files) {
+    file_handlers.push_back(std::make_unique<TAFileHandler>(file, config, worker_threads));
+  }
+
+  // Start each file handler
+  for (const auto& handler : file_handlers) {
+    handler->start_processing();
+  }
+
+  for (const auto& handler : file_handlers) {
+    handler->wait_to_complete_work();
+  }
+  std::cout << "All threads joined" << std::endl;
+
+
+  // Extract & sort all the TAs when ready
+
+  return 0;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,9 @@ The `trgtools` repository contains a collection of tools and scripts to emulate,
 
 Use `pip install -r requirements.txt` to install all the Python packages necessary to run the `*_dump.py` scripts and the `trgtools.plot` submodule.
 
-- `process_tpstream`: Example of a simple pipeline to process TPStream files (slice by slice) and apply a trigger algorithms (single plane, inc. latency measurements). [Documentation](process-tpstream.md).
 - `emulate_from_tpstream`: Prototype of a full pipeline to process TPStream files and apply trigger algorithms (multiple planes & APA/CRPs, no latency measurements yet) [Documentation](emulate-from-tpstream.md).
+- `plot_emulated_triggers`: Script that loads HDF5 file generated from `emulate_from_tpstream` and plots TriggerCandidates, one per page. For each TriggerCandidate it plots each TriggerActivity that is contained in the TC, and all the TPs contained within the TA objects. [Documentation](plot-emulated-triggers.md)
+- `process_tpstream`: Example of a simple pipeline to process TPStream files (slice by slice) and apply a trigger algorithms (single plane, inc. latency measurements). [Documentation](process-tpstream.md).
 - `ta_dump.py`: Script that loads HDF5 files containing trigger activities and plots various diagnostic information. [Documentation](ta-dump.md).
 - `tc_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](tc-dump.md).
 - `tp_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](tp-dump.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,8 @@ The `trgtools` repository contains a collection of tools and scripts to emulate,
 
 Use `pip install -r requirements.txt` to install all the Python packages necessary to run the `*_dump.py` scripts and the `trgtools.plot` submodule.
 
-- `process_tpstream`: Example of a simple pipeline to process TPStream files (slice by slice) and apply a trigger activity algorithm. [Documentation](process-tpstream.md).
+- `process_tpstream`: Example of a simple pipeline to process TPStream files (slice by slice) and apply a trigger algorithms (single plane, inc. latency measurements). [Documentation](process-tpstream.md).
+- `emulate_from_tpstream`: Prototype of a full pipeline to process TPStream files and apply trigger algorithms (multiple planes & APA/CRPs, no latency measurements yet) [Documentation](emulate-from-tpstream.md).
 - `ta_dump.py`: Script that loads HDF5 files containing trigger activities and plots various diagnostic information. [Documentation](ta-dump.md).
 - `tc_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](tc-dump.md).
 - `tp_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](tp-dump.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,3 +12,52 @@ Use `pip install -r requirements.txt` to install all the Python packages necessa
 - `tp_dump.py`: Script that loads HDF5 files containing trigger primitives and plots various diagnostic information. [Documentation](tp-dump.md).
 - `convert_tplatencies.py`: Script that loads HDF5 files and CSV `ta_timings_` files from `process_tpstream` with `--latencies` enabled, and outputs simplified CSV latencies per-TA. [Documentation](convert-tplatencies.md).
 - Python `trgtools` module: Reading and plotting module in that specializes in reading TP, TA, and TC fragments for a given HDF5. The submodule `trgtools.plot` has a common `PDFPlotter` that is used in the `*_dump.py` scripts. [Documentation](py-trgtools.md).
+
+## Configuration
+
+Both `emulate_from_tpstream` and `process_tpstream` require a `.json` file with the trigger algorithm configuration, which includes one `TAMaker` and one `TCMaker`. 
+
+The `algo_config.json` configuration below mirrors the format that is used in v4 `daqconf` and the current trigger algorithm setup (it was not ported to OKS due to compatibilities with the offline software). An example is shown below.
+
+```json
+{
+  "trigger_activity_config": [
+    {
+      "adc_threshold": 10000,
+      "adj_tolerance": 4,
+      "adjacency_threshold": 6,
+      "n_channels_threshold": 8,
+      "prescale": 100,
+      "print_tp_info": false,
+      "trigger_on_adc": false,
+      "trigger_on_adjacency": true,
+      "trigger_on_n_channels": false,
+      "window_length": 10000,
+      "max_time_over_threshold": 10000
+    }
+  ],
+  "trigger_activity_plugin": [
+    "TAMakerPrescaleAlgorithm"
+  ],
+  "trigger_candidate_config": [
+    {
+      "adc_threshold": 10000,
+      "adj_tolerance": 4,
+      "adjacency_threshold": 6,
+      "n_channels_threshold": 8,
+      "prescale": 100,
+      "print_tp_info": false,
+      "trigger_on_adc": false,
+      "trigger_on_adjacency": true,
+      "trigger_on_n_channels": false,
+      "window_length": 10000,
+      "tc_type_name": "kPrescale"
+    }
+  ],
+  "trigger_candidate_plugin": [
+    "TCMakerPrescaleAlgorithm"
+  ]
+}
+```
+
+When developing new algorithms, it is sufficient to change the plugin name and insert the new configurable parameters.

--- a/docs/emulate-from-tpstream.md
+++ b/docs/emulate-from-tpstream.md
@@ -21,6 +21,7 @@ appropriate.
 **WARNING:** This script is different from `process_tpstream`, and does not
 contain all the functionality yet. Look at TODOs below for more info.
 
+
 ## Example
 
 ```bash
@@ -28,6 +29,10 @@ trgtools_emulate_from_tpstream -i input_file.hdf5 -o output_file.hdf5 -j algo_co
 
 trgtools_emulate_from_tpstream -i input_file_APA*.hdf5 -o output_file.hdf5 -j algo_config.json
 ```
+
+### Parallelisation
+
+You can run the emulator with `--parallel`, which will not only process each TPWriter separately, but each TAMaker too. **This is currently only worth trying if using slow algo, like DBSCAN**, otherwise it can be marginally slower.
 
 ## TODOs
 

--- a/docs/emulate-from-tpstream.md
+++ b/docs/emulate-from-tpstream.md
@@ -6,7 +6,8 @@ new HDF5 that includes TriggerActivities and TriggerCandidates.
 
 The primary use of this is to test TA algorithms, TC algorithms, and their
 configurations, with output diagnostics available from `ta_dump.py` and
-`tc_dump.py`.
+`tc_dump.py`. The full TC displays that include all TAs & TPs within those TAs
+can be made with the `plot_emulated_triggers.pd` script.
 
 The application understands that there might be multiple sources of trigger
 primitives, that different files might contain TPs from different sources

--- a/docs/emulate-from-tpstream.md
+++ b/docs/emulate-from-tpstream.md
@@ -9,7 +9,7 @@ configurations, with output diagnostics available from `ta_dump.py` and
 `tc_dump.py`.
 
 The application understands that there might be multiple sources of trigger
-primitives, that differnet files will might contain TPs from different sources
+primitives, that different files might contain TPs from different sources
 (e.g. two APAs), or that different files might contain TPs from the same sources
 but across different time-periods (e.g. two consecutive files from the same
 APAs).

--- a/docs/emulate-from-tpstream.md
+++ b/docs/emulate-from-tpstream.md
@@ -1,24 +1,38 @@
-# Processing TP Streams
+# Emulate from TP Stream
+
 `emulate_from_tpstream.cxx` (and the application `trgtools_emulate_from_tpstream`)
 processes timeslice HDF5 files that contain TriggerPrimitives, and creates a
 new HDF5 that includes TriggerActivities and TriggerCandidates.
 
 The primary use of this is to test TA algorithms, TC algorithms, and their
 configurations, with output diagnostics available from `ta_dump.py` and
-`tc_dump.py`. 
+`tc_dump.py`.
 
 The application understands that there might be multiple sources of trigger
-primitives, that differnet files will might contain TPs from different sources,
-or that different files might contain TPs from the same sources but across
-different time-periods.
+primitives, that differnet files will might contain TPs from different sources
+(e.g. two APAs), or that different files might contain TPs from the same sources
+but across different time-periods (e.g. two consecutive files from the same
+APAs).
 
-Although the user can select the specific timeslice ranges to process, the
-application will first check if we have TPs from all the available sources for
-the specified slices -- and crop the requested timeslice ranges as appropriate.
+The application will first check if we have TPs from all the available sources
+for the specified slices -- and crop the requested timeslice ranges as
+appropriate.
+
+**WARNING:** This script is different from `process_tpstream`, and does not
+contain all the functionality yet. Look at TODOs below for more info.
 
 ## Example
+
 ```bash
 trgtools_emulate_from_tpstream -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json -m VDColdboxChannelMap --quiet
 
-trgtools_emulate_from_tpstream --latencies -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json
+trgtools_emulate_from_tpstream -i input_file_APA*.hdf5 -o output_file.hdf5 -j algo_config.json
 ```
+
+## TODOs
+
+1. **Latency measurements**: At the moment the script does not calculate latencies for each TP->TA->TC in a way that `convert-tplatencies` does -- and that needs to be corrected.
+2. **PDS TP Emulation**: Should be easy to add, but at the moment only works for TPC.
+3. **SliceID -> Time error checks**: At the moment the code looks for matching `SliceID`s across different files, and cnverges on a `SliceID` "window" to get the TPs from. Although rare, it should be possible to have matching `SliceID`s with mismatching times -- we need to go off actual TP times, rather than `SliceID`s.
+4. **Choose time-slice**: The user currently cannot choose time-slice to plot: the script will match the largest timeslice available across TPWriters provided. That has to be done with combination of the above, so e.g. allow for "time offset" and "time range" to plot for (in ticks, seconds, or whatever)
+5. **Parallelisation**: could be optimised further.

--- a/docs/emulate-from-tpstream.md
+++ b/docs/emulate-from-tpstream.md
@@ -1,0 +1,24 @@
+# Processing TP Streams
+`emulate_from_tpstream.cxx` (and the application `trgtools_emulate_from_tpstream`)
+processes timeslice HDF5 files that contain TriggerPrimitives, and creates a
+new HDF5 that includes TriggerActivities and TriggerCandidates.
+
+The primary use of this is to test TA algorithms, TC algorithms, and their
+configurations, with output diagnostics available from `ta_dump.py` and
+`tc_dump.py`. 
+
+The application understands that there might be multiple sources of trigger
+primitives, that differnet files will might contain TPs from different sources,
+or that different files might contain TPs from the same sources but across
+different time-periods.
+
+Although the user can select the specific timeslice ranges to process, the
+application will first check if we have TPs from all the available sources for
+the specified slices -- and crop the requested timeslice ranges as appropriate.
+
+## Example
+```bash
+trgtools_emulate_from_tpstream -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json -m VDColdboxChannelMap --quiet
+
+trgtools_emulate_from_tpstream --latencies -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json
+```

--- a/docs/emulate-from-tpstream.md
+++ b/docs/emulate-from-tpstream.md
@@ -21,14 +21,17 @@ appropriate.
 **WARNING:** This script is different from `process_tpstream`, and does not
 contain all the functionality yet. Look at TODOs below for more info.
 
-
 ## Example
 
 ```bash
-trgtools_emulate_from_tpstream -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json -m VDColdboxChannelMap --quiet
+trgtools_emulate_from_tpstream -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json --quiet 
 
 trgtools_emulate_from_tpstream -i input_file_APA*.hdf5 -o output_file.hdf5 -j algo_config.json
 ```
+
+### Algorithm Configuration
+
+An example `algo_config.json` file with an explenanation are provided [HERE](README.md#configuration).
 
 ### Parallelisation
 

--- a/docs/emulate-from-tpstream.md
+++ b/docs/emulate-from-tpstream.md
@@ -31,7 +31,7 @@ trgtools_emulate_from_tpstream -i input_file_APA*.hdf5 -o output_file.hdf5 -j al
 
 ### Algorithm Configuration
 
-An example `algo_config.json` file with an explenanation are provided [HERE](README.md#configuration).
+An example `algo_config.json` file with an explanation are provided [HERE](README.md#configuration).
 
 ### Parallelisation
 

--- a/docs/plot-emulated-triggers.md
+++ b/docs/plot-emulated-triggers.md
@@ -9,8 +9,8 @@ While running, this can print information about the file reading using `-v` (war
 ## Example
 
 ```bash
-python plot_emilated_triggers.py file.hdf5
-python plot_emilated_triggers.py file.hdf5 -v
-python plot_emilated_triggers.py file.hdf5 -vv
-python plot_emilated_triggers.py file.hdf5 --help
+python plot_emulated_triggers.py file.hdf5
+python plot_emulated_triggers.py file.hdf5 -v
+python plot_emulated_triggers.py file.hdf5 -vv
+python plot_emulated_triggers.py file.hdf5 --help
 ```

--- a/docs/plot-emulated-triggers.md
+++ b/docs/plot-emulated-triggers.md
@@ -1,0 +1,17 @@
+# Plot Emulated Triggers
+
+`plot_emulated_triggers.py` is a plotting script that generates one plot for each TriggerCandidate in one PDF. For each TriggerCandidate page, TriggerActivities contained within the TC object are shown in a red box, and TPs contained in each of these TAs are shown as black marker points.
+
+By default, a new PDF is generated (with naming based on the existing PDFs). One can pass `--overwrite` to overwrite the 0th PDF for a given HDF5 file.
+
+While running, this can print information about the file reading using `-v` (warnings) and `-vv` (all). Errors and useful output information (save names and location) are always outputted.
+
+## Example
+
+```bash
+python tc_dump.py file.hdf5
+python tc_dump.py file.hdf5 --overwrite
+python tc_dump.py file.hdf5 -v
+python tc_dump.py file.hdf5 -vv
+python tc_dump.py file.hdf5 --help
+```

--- a/docs/plot-emulated-triggers.md
+++ b/docs/plot-emulated-triggers.md
@@ -9,9 +9,9 @@ While running, this can print information about the file reading using `-v` (war
 ## Example
 
 ```bash
-python tc_dump.py file.hdf5
-python tc_dump.py file.hdf5 --overwrite
-python tc_dump.py file.hdf5 -v
-python tc_dump.py file.hdf5 -vv
-python tc_dump.py file.hdf5 --help
+python plot_emilated_triggers.py file.hdf5
+python plot_emilated_triggers.py file.hdf5 --overwrite
+python plot_emilated_triggers.py file.hdf5 -v
+python plot_emilated_triggers.py file.hdf5 -vv
+python plot_emilated_triggers.py file.hdf5 --help
 ```

--- a/docs/plot-emulated-triggers.md
+++ b/docs/plot-emulated-triggers.md
@@ -2,7 +2,7 @@
 
 `plot_emulated_triggers.py` is a plotting script that generates one plot for each TriggerCandidate in one PDF. For each TriggerCandidate page, TriggerActivities contained within the TC object are shown in a red box, and TPs contained in each of these TAs are shown as black marker points.
 
-By default, a new PDF is generated (with naming based on the existing PDFs). One can pass `--overwrite` to overwrite the 0th PDF for a given HDF5 file.
+By default, a new PDF is generated (with naming based on the existing PDFs).
 
 While running, this can print information about the file reading using `-v` (warnings) and `-vv` (all). Errors and useful output information (save names and location) are always outputted.
 
@@ -10,7 +10,6 @@ While running, this can print information about the file reading using `-v` (war
 
 ```bash
 python plot_emilated_triggers.py file.hdf5
-python plot_emilated_triggers.py file.hdf5 --overwrite
 python plot_emilated_triggers.py file.hdf5 -v
 python plot_emilated_triggers.py file.hdf5 -vv
 python plot_emilated_triggers.py file.hdf5 --help

--- a/docs/process-tpstream.md
+++ b/docs/process-tpstream.md
@@ -1,53 +1,17 @@
 # Processing TP Streams
+
 `process_tpstream.cxx` (and the application `trgtools_process_tpstream`) processes a timeslice HDF5 that contains TriggerPrimitives and creates a new HDF5 that also includes TriggerActivities and TriggerCandidates. The primary use of this is to test TA algorithms, TC algorithms, and their configurations, with output diagnostics available from `ta_dump.py` and `tc_dump.py`. The application also outputs the latencies per-tp for TA emulation, and per-TA for TC emulation, into a CSV file, if `--latencies` option is added. The CSV is the format: row as a TP (TA) for TA(TC) emulation, with `time_start`, `adc_integral`, `processing time`, and whether it was TP that closed TA (1) or not (0).
 
 ## Example
+
 ```bash
 trgtools_process_tpstream -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json -m VDColdboxChannelMap --quiet
 
 trgtools_process_tpstream --latencies -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json
 ```
+
 In the second case, the default map will be `VDColdboxChannelMap`. The `DUNE-DAQ/detchannelmaps` repository has a [table of available channel maps](https://github.com/DUNE-DAQ/detchannelmaps/blob/develop/docs/channel-maps-table.md).
 
-### Configuration
-The `algo_config.json` configuration mirrors the format that is used in `daqconf`. An example is shown below.
-```
-{
-	"trigger_activity_config": [
-	    {
-		"adc_threshold": 10000,
-		"adj_tolerance": 4,
-		"adjacency_threshold": 6,
-		"n_channels_threshold": 8,
-		"prescale": 100,
-		"print_tp_info": false,
-		"trigger_on_adc": false,
-		"trigger_on_adjacency": true,
-		"trigger_on_n_channels": false,
-		"window_length": 10000,
-		"max_time_over_threshold": 10000
-	    }
-	],
-	"trigger_activity_plugin": [
-	    "TAMakerPrescaleAlgorithm"
-	],
-	"trigger_candidate_config": [
-	    {
-		"adc_threshold": 10000,
-		"adj_tolerance": 4,
-		"adjacency_threshold": 6,
-		"n_channels_threshold": 8,
-		"prescale": 100,
-		"print_tp_info": false,
-		"trigger_on_adc": false,
-		"trigger_on_adjacency": true,
-		"trigger_on_n_channels": false,
-		"window_length": 10000
-	    }
-	],
-	"trigger_candidate_plugin": [
-	    "TCMakerPrescaleAlgorithm"
-	]
-}
-```
-When developing new algorithms, it is sufficient to change the plugin name and insert the new configurable parameters.
+## Algorithm Configuration
+
+An example `algo_config.json` file with an explenanation are provided [HERE](README.md#configuration).

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -1,0 +1,77 @@
+#ifndef TRGTOOLS_TAFILEHANDLER_HPP_
+#define TRGTOOLS_TAFILEHANDLER_HPP_
+
+#include "trgtools/EmulateTAUnit.hpp"
+#include "trgtools/EmulateTCUnit.hpp"
+
+#include "CLI/App.hpp"
+#include "CLI/Config.hpp"
+#include "CLI/Formatter.hpp"
+
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/chrono.h>
+#include <filesystem>
+
+#include "hdf5libs/HDF5RawDataFile.hpp"
+#include "trgdataformats/TriggerPrimitive.hpp"
+#include "triggeralgs/TriggerActivityFactory.hpp"
+#include "triggeralgs/TriggerCandidateFactory.hpp"
+#include "triggeralgs/TriggerObjectOverlay.hpp"
+#include "detchannelmaps/TPCChannelMap.hpp"
+
+
+namespace dunedaq::trgtools 
+{
+
+class TAFileHandler
+{
+  public:
+    TAFileHandler(std::string input_path, nlohmann::json config, size_t n_threads = 0);
+
+    ~TAFileHandler() = default;
+  
+    void start_processing(uint64_t time = 0, bool quiet=false);
+
+    void wait_to_complete_work();
+
+  private:
+    void process_tasks(uint64_t time, bool quiet);
+
+    void process_task(int thread_id, uint64_t rec, std::vector<trgdataformats::TriggerPrimitive> tps, uint64_t time, bool quiet);
+
+    void worker_thread();
+
+    void enqueue_task(std::function<void()> task);
+
+    void wait_to_complete_tasks();
+
+  private:
+    /// @brief A pointer to the input file
+    std::unique_ptr<hdf5libs::HDF5RawDataFile> m_input_file;
+
+    /// @brief configuration for the TA-makers
+    nlohmann::json m_configuration;
+
+    /// Vector of TA-processors
+    std::vector<std::function<void(daqdataformats::Fragment&)>> m_processors;
+    std::vector<std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
+
+    /// Output vector of TAs
+    std::vector<triggeralgs::TriggerActivity> m_trigger_activities;
+
+    std::string m_input_path;
+
+    std::thread m_main_thread;
+    std::vector<std::thread> m_thread_pool;
+    std::queue<std::function<void()>> m_task_queue;
+    std::mutex m_queue_mutex;
+    std::condition_variable m_condition;
+    std::condition_variable m_task_complete_condition;
+    std::atomic<bool> m_stop{false};
+    std::atomic<size_t> m_active_tasks;
+    size_t m_num_threads;
+};
+};
+
+#endif

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -29,8 +29,13 @@ class TAFileHandler
   public:
     /**
      * @brief Constructor, takes file input path & configuration
+     * @param _quiet Do we want to print logs?
      */
-    TAFileHandler(std::string input_path, nlohmann::json config, std::pair<uint64_t, uint64_t> sliceid_range);
+    TAFileHandler(std::string input_path, 
+                  nlohmann::json config,
+                  std::pair<uint64_t, uint64_t> sliceid_range,
+                  bool run_parallel,
+                  bool quiet);
 
     ~TAFileHandler() = default;
 
@@ -39,8 +44,8 @@ class TAFileHandler
     /**
      * @brief User interaction for task processing
      */
-    void start_processing(uint64_t time = 0,
-                          bool quiet=false);
+    void start_processing();
+                          
 
     /// @brief Waits for all the tasks to complete
     void wait_to_complete_work();
@@ -54,33 +59,22 @@ class TAFileHandler
     hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t get_sourceid_geoid_map();
 
 
-
-
-
   private:
     /**
      * @brief Function that processes the whole file
-     *
-     * @param _time The amount of time we want to process
-     * @param _quiet Do we want to print logs?
      */
-    void process_tasks(uint64_t _time,
-                       bool _quiet);
+    void process_tasks();
 
     /**
      * @brief Function that processes one slice for one plane
      *
      * @param _source_id
      * @param _tps
-     * @param _time
-     * @param _quiet
      */
     void process_task(daqdataformats::SourceID _source_id,
                       uint64_t _rec,
                       daqdataformats::FragmentHeader _header,
-                      std::vector<trgdataformats::TriggerPrimitive> _tps,
-                      uint64_t _time,
-                      bool _quiet);
+                      std::vector<trgdataformats::TriggerPrimitive>&& _tps);
 
     /// @brief
     void worker_thread();
@@ -88,10 +82,10 @@ class TAFileHandler
     /**
      * @brief
      */
-    //void enqueue_task(std::function<void()> task);
+    void enqueue_task(std::function<void()> task);
 
     /// @brief
-    //void wait_to_complete_tasks();
+    void wait_to_complete_tasks();
 
   private:
     /// @brief A pointer to the input file
@@ -100,26 +94,42 @@ class TAFileHandler
     /// @brief configuration for the TA-makers
     nlohmann::json m_configuration;
 
+    /// @brief input vector of tpstream input paths
+    std::vector<std::string> m_input_paths;
+
     /// @brief Vector of TA emulators
     //std::vector<std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
     std::map<daqdataformats::SourceID, std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
 
-
-    /// @brief input vector of tpstream input paths
-    std::vector<std::string> m_input_paths;
-
     /// @brief Range of TimeSlice IDs to process
     std::pair<uint64_t, uint64_t> m_sliceid_range;
 
+    /// @brief Run the TA makers in parllel
+    const bool m_run_parallel;
+
+    /// @brief Quiet down the cout output
+    const bool m_quiet;
+
+    /*
+     * Threading objects for the main file handler
+     */
+    /// @brief The file handler thread
     std::thread m_main_thread;
-    //std::vector<std::thread> m_thread_pool;
-    //std::queue<std::function<void()>> m_task_queue;
-    //std::mutex m_queue_mutex;
+    std::atomic<bool> m_stop{false};
+
+    /*
+     * Optional threading objects for the tasks
+     * i.e. one thread per TAMaker
+     */
+
+    /// @brief Mutex for saving the TPs
     std::mutex m_savetps_mutex;
+    std::vector<std::thread> m_thread_pool;
     std::condition_variable m_condition;
     std::condition_variable m_task_complete_condition;
-    std::atomic<bool> m_stop{false};
-    //std::atomic<size_t> m_active_tasks;
+    std::queue<std::function<void()>> m_task_queue;
+    std::mutex m_queue_mutex;
+    std::atomic<size_t> m_active_tasks;
 
     /// @brief Output vector of TAs
     std::map<uint64_t, std::vector<triggeralgs::TriggerActivity>> m_tas;
@@ -129,6 +139,7 @@ class TAFileHandler
 
     uint16_t m_id;
     static uint16_t m_id_next;
+    static const size_t SIZE_TP  = sizeof(trgdataformats::TriggerPrimitive);
 };
 
 };

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -30,7 +30,7 @@ class TAFileHandler
     /**
      * @brief Constructor, takes file input path & configuration
      * 
-     * Each TAFileHandler will crete its own thread, so all TAFileHandlers are
+     * Each TAFileHandler will create its own thread, so all TAFileHandlers are
      * run on separate threads
      * 
      * @param _input_files a vector of input HDF5 shared pointers to process

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -63,7 +63,7 @@ class TAFileHandler
     void wait_to_complete_work();
 
     /**
-     * @brief Retreives all the TAs with std::move operator
+     * @brief Retrieves all the TAs with std::move operator
      * 
      * @return a map of sourceID : TA
      */

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -33,6 +33,8 @@ class TAFileHandler
     TAFileHandler(std::string input_path, nlohmann::json config, std::pair<uint64_t, uint64_t> sliceid_range);
 
     ~TAFileHandler() = default;
+
+    std::vector<daqdataformats::SourceID> get_valid_sourceids(daqdataformats::TimeSlice& _timeslice);
   
     /**
      * @brief User interaction for task processing
@@ -49,8 +51,11 @@ class TAFileHandler
     /// @brief Retreives all the unique pointers to the TA fragments
     std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> get_frags();
 
-    hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t
-    get_sourceid_geoid_map();
+    hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t get_sourceid_geoid_map();
+
+
+
+
 
   private:
     /**
@@ -65,12 +70,12 @@ class TAFileHandler
     /**
      * @brief Function that processes one slice for one plane
      *
-     * @param _thread_id
+     * @param _source_id
      * @param _tps
      * @param _time
      * @param _quiet
      */
-    void process_task(int _thread_id,
+    void process_task(daqdataformats::SourceID _source_id,
                       uint64_t _rec,
                       daqdataformats::FragmentHeader _header,
                       std::vector<trgdataformats::TriggerPrimitive> _tps,
@@ -96,7 +101,9 @@ class TAFileHandler
     nlohmann::json m_configuration;
 
     /// @brief Vector of TA emulators
-    std::vector<std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
+    //std::vector<std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
+    std::map<daqdataformats::SourceID, std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
+
 
     /// @brief input vector of tpstream input paths
     std::vector<std::string> m_input_paths;

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -2,7 +2,6 @@
 #define TRGTOOLS_TAFILEHANDLER_HPP_
 
 #include "trgtools/EmulateTAUnit.hpp"
-#include "trgtools/EmulateTCUnit.hpp"
 
 #include "CLI/App.hpp"
 #include "CLI/Config.hpp"
@@ -16,10 +15,7 @@
 #include "hdf5libs/HDF5RawDataFile.hpp"
 #include "trgdataformats/TriggerPrimitive.hpp"
 #include "triggeralgs/TriggerActivityFactory.hpp"
-#include "triggeralgs/TriggerCandidateFactory.hpp"
 #include "triggeralgs/TriggerObjectOverlay.hpp"
-#include "detchannelmaps/TPCChannelMap.hpp"
-
 
 namespace dunedaq::trgtools 
 {

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -31,7 +31,7 @@ class TAFileHandler
      * @brief Constructor, takes file input path & configuration
      * @param _quiet Do we want to print logs?
      */
-    TAFileHandler(std::string input_path, 
+    TAFileHandler(std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>> input_files,
                   nlohmann::json config,
                   std::pair<uint64_t, uint64_t> sliceid_range,
                   bool run_parallel,
@@ -45,7 +45,6 @@ class TAFileHandler
      * @brief User interaction for task processing
      */
     void start_processing();
-                          
 
     /// @brief Waits for all the tasks to complete
     void wait_to_complete_work();
@@ -89,7 +88,7 @@ class TAFileHandler
 
   private:
     /// @brief A pointer to the input file
-    std::unique_ptr<hdf5libs::HDF5RawDataFile> m_input_file;
+    std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>> m_input_files;
 
     /// @brief configuration for the TA-makers
     nlohmann::json m_configuration;

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -71,7 +71,7 @@ class TAFileHandler
     get_tas();
 
     /**
-     * @brief Retreives all the unique pointers to the TA fragments
+     * @brief Retrieves all the unique pointers to the TA fragments
      * 
      * @return A map of sourceID : TA fragment
      */

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -29,61 +29,92 @@ class TAFileHandler
   public:
     /**
      * @brief Constructor, takes file input path & configuration
-     * @param _quiet Do we want to print logs?
+     * 
+     * Each TAFileHandler will crete its own thread, so all TAFileHandlers are
+     * run on separate threads
+     * 
+     * @param _input_files a vector of input HDF5 shared pointers to process
+     * @param _config TAMaker configuration
+     * @param _sliceid_range range of sliceids to process
+     * @param _run_parallel run each TAMaker (one per SourceID) in parallel
+     * @param _quiet quiet down the cout
      */
-    TAFileHandler(std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>> input_files,
-                  nlohmann::json config,
-                  std::pair<uint64_t, uint64_t> sliceid_range,
-                  bool run_parallel,
-                  bool quiet);
+    TAFileHandler(std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>> _input_files,
+                  nlohmann::json _config,
+                  std::pair<uint64_t, uint64_t> _sliceid_range,
+                  bool _run_parallel,
+                  bool _quiet);
 
     ~TAFileHandler() = default;
 
-    std::vector<daqdataformats::SourceID> get_valid_sourceids(daqdataformats::TimeSlice& _timeslice);
-  
     /**
-     * @brief User interaction for task processing
+     * @brief Get the valid sourceids object from HDF5 file
+     * 
+     * @param _timeslice timeslice to load the sourceIDs from
+     * @return vector of SoureIDs from this file
      */
+    std::vector<daqdataformats::SourceID>
+    get_valid_sourceids(daqdataformats::TimeSlice& _timeslice);
+  
+    /// @brief User interaction for task processing
     void start_processing();
 
     /// @brief Waits for all the tasks to complete
     void wait_to_complete_work();
 
-    /// @brief Retreives all the TAs with std::move operator
-    std::map<uint64_t, std::vector<triggeralgs::TriggerActivity>> get_tas();
+    /**
+     * @brief Retreives all the TAs with std::move operator
+     * 
+     * @return a map of sourceID : TA
+     */
+    std::map<uint64_t, std::vector<triggeralgs::TriggerActivity>>
+    get_tas();
 
-    /// @brief Retreives all the unique pointers to the TA fragments
-    std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> get_frags();
+    /**
+     * @brief Retreives all the unique pointers to the TA fragments
+     * 
+     * @return A map of sourceID : TA fragment
+     */
+    std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>>
+    get_frags();
 
-    hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t get_sourceid_geoid_map();
+    /**
+     * @brief Get the sourceid to geoid map object
+     * 
+     * @return geoid to sourceid map
+     */
+    hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t
+    get_sourceid_geoid_map();
 
 
   private:
-    /**
-     * @brief Function that processes the whole file
-     */
+    /// @brief Function that processes the whole file
     void process_tasks();
 
     /**
      * @brief Function that processes one slice for one plane
      *
-     * @param _source_id
-     * @param _tps
+     * @param _source_id sourceID to process
+     * @param _rec record ID to process
+     * @param _header fragment header
+     * @param _tps vectors of trigger primitives to process (with move operator)
      */
     void process_task(daqdataformats::SourceID _source_id,
                       uint64_t _rec,
                       daqdataformats::FragmentHeader _header,
                       std::vector<trgdataformats::TriggerPrimitive>&& _tps);
 
-    /// @brief
+    /// @brief Creates & runs a worker thread
     void worker_thread();
 
     /**
-     * @brief
+     * @brief Enqueues task to process 
+     * 
+     * @param task task to porcess
      */
     void enqueue_task(std::function<void()> task);
 
-    /// @brief
+    /// @brief Waits to complete a task
     void wait_to_complete_tasks();
 
   private:
@@ -96,8 +127,7 @@ class TAFileHandler
     /// @brief input vector of tpstream input paths
     std::vector<std::string> m_input_paths;
 
-    /// @brief Vector of TA emulators
-    //std::vector<std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
+    /// @brief Map of SourceID : Emulator unit (TAMaker)
     std::map<daqdataformats::SourceID, std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
 
     /// @brief Range of TimeSlice IDs to process
@@ -112,8 +142,11 @@ class TAFileHandler
     /*
      * Threading objects for the main file handler
      */
+
     /// @brief The file handler thread
     std::thread m_main_thread;
+
+    /// @brief Bool to indicate to stop the emulation
     std::atomic<bool> m_stop{false};
 
     /*
@@ -136,8 +169,11 @@ class TAFileHandler
     /// @brief Output vector of TA fragments
     std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> m_ta_fragments;
 
+    /// @brief Unique ID for this TAFileHandler
     uint16_t m_id;
+    /// @brief Global variable used to get the next ID
     static uint16_t m_id_next;
+    /// @brief Size of the TPS
     static const size_t SIZE_TP  = sizeof(trgdataformats::TriggerPrimitive);
 };
 

--- a/include/trgtools/TAFileHandler.hpp
+++ b/include/trgtools/TAFileHandler.hpp
@@ -27,24 +27,66 @@ namespace dunedaq::trgtools
 class TAFileHandler
 {
   public:
-    TAFileHandler(std::string input_path, nlohmann::json config, size_t n_threads = 0);
+    /**
+     * @brief Constructor, takes file input path & configuration
+     */
+    TAFileHandler(std::string input_path, nlohmann::json config, std::pair<uint64_t, uint64_t> sliceid_range);
 
     ~TAFileHandler() = default;
   
-    void start_processing(uint64_t time = 0, bool quiet=false);
+    /**
+     * @brief User interaction for task processing
+     */
+    void start_processing(uint64_t time = 0,
+                          bool quiet=false);
 
+    /// @brief Waits for all the tasks to complete
     void wait_to_complete_work();
 
+    /// @brief Retreives all the TAs with std::move operator
+    std::map<uint64_t, std::vector<triggeralgs::TriggerActivity>> get_tas();
+
+    /// @brief Retreives all the unique pointers to the TA fragments
+    std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> get_frags();
+
+    hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t
+    get_sourceid_geoid_map();
+
   private:
-    void process_tasks(uint64_t time, bool quiet);
+    /**
+     * @brief Function that processes the whole file
+     *
+     * @param _time The amount of time we want to process
+     * @param _quiet Do we want to print logs?
+     */
+    void process_tasks(uint64_t _time,
+                       bool _quiet);
 
-    void process_task(int thread_id, uint64_t rec, std::vector<trgdataformats::TriggerPrimitive> tps, uint64_t time, bool quiet);
+    /**
+     * @brief Function that processes one slice for one plane
+     *
+     * @param _thread_id
+     * @param _tps
+     * @param _time
+     * @param _quiet
+     */
+    void process_task(int _thread_id,
+                      uint64_t _rec,
+                      daqdataformats::FragmentHeader _header,
+                      std::vector<trgdataformats::TriggerPrimitive> _tps,
+                      uint64_t _time,
+                      bool _quiet);
 
+    /// @brief
     void worker_thread();
 
-    void enqueue_task(std::function<void()> task);
+    /**
+     * @brief
+     */
+    //void enqueue_task(std::function<void()> task);
 
-    void wait_to_complete_tasks();
+    /// @brief
+    //void wait_to_complete_tasks();
 
   private:
     /// @brief A pointer to the input file
@@ -53,25 +95,35 @@ class TAFileHandler
     /// @brief configuration for the TA-makers
     nlohmann::json m_configuration;
 
-    /// Vector of TA-processors
-    std::vector<std::function<void(daqdataformats::Fragment&)>> m_processors;
+    /// @brief Vector of TA emulators
     std::vector<std::unique_ptr<trgtools::EmulateTAUnit>> m_ta_emulators;
 
-    /// Output vector of TAs
-    std::vector<triggeralgs::TriggerActivity> m_trigger_activities;
+    /// @brief input vector of tpstream input paths
+    std::vector<std::string> m_input_paths;
 
-    std::string m_input_path;
+    /// @brief Range of TimeSlice IDs to process
+    std::pair<uint64_t, uint64_t> m_sliceid_range;
 
     std::thread m_main_thread;
-    std::vector<std::thread> m_thread_pool;
-    std::queue<std::function<void()>> m_task_queue;
-    std::mutex m_queue_mutex;
+    //std::vector<std::thread> m_thread_pool;
+    //std::queue<std::function<void()>> m_task_queue;
+    //std::mutex m_queue_mutex;
+    std::mutex m_savetps_mutex;
     std::condition_variable m_condition;
     std::condition_variable m_task_complete_condition;
     std::atomic<bool> m_stop{false};
-    std::atomic<size_t> m_active_tasks;
-    size_t m_num_threads;
+    //std::atomic<size_t> m_active_tasks;
+
+    /// @brief Output vector of TAs
+    std::map<uint64_t, std::vector<triggeralgs::TriggerActivity>> m_tas;
+
+    /// @brief Output vector of TA fragments
+    std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> m_ta_fragments;
+
+    uint16_t m_id;
+    static uint16_t m_id_next;
 };
+
 };
 
 #endif

--- a/python/trgtools/HDF5Reader.py
+++ b/python/trgtools/HDF5Reader.py
@@ -2,6 +2,7 @@
 Generic HDF5Reader class to read and store data.
 """
 from hdf5libs import HDF5RawDataFile
+from tqdm import tqdm 
 
 import abc
 
@@ -71,7 +72,7 @@ class HDF5Reader(abc.ABC):
 
     def read_all_fragments(self) -> None:
         """ Read all fragments. """
-        for fragment_path in self._fragment_paths:
+        for fragment_path in tqdm(self._fragment_paths, desc='Reading all the fragments'):
             _ = self.read_fragment(fragment_path)
 
         # self.read_fragment should increment self._num_empty.

--- a/python/trgtools/HDF5Reader.py
+++ b/python/trgtools/HDF5Reader.py
@@ -22,7 +22,7 @@ class HDF5Reader(abc.ABC):
     _END_TEXT_COLOR = '\033[0m'
 
 
-    def __init__(self, filename: str, verbosity: int = 0) -> None:
+    def __init__(self, filename: str, verbosity: int = 0, batch_mode: bool = False) -> None:
         """
         Loads a given HDF5 file.
 
@@ -43,6 +43,8 @@ class HDF5Reader(abc.ABC):
         self._filter_fragment_paths()  # Derived class must define this.
 
         self._num_empty = 0  # Counts the number of empty fragments.
+
+        self._batch_mode = batch_mode
 
         return None
 
@@ -72,7 +74,7 @@ class HDF5Reader(abc.ABC):
 
     def read_all_fragments(self) -> None:
         """ Read all fragments. """
-        for fragment_path in tqdm(self._fragment_paths, desc='Reading all the fragments'):
+        for fragment_path in tqdm(self._fragment_paths, desc='Reading all the fragments', disable=self._batch_mode):
             _ = self.read_fragment(fragment_path)
 
         # self.read_fragment should increment self._num_empty.

--- a/python/trgtools/TAReader.py
+++ b/python/trgtools/TAReader.py
@@ -56,7 +56,7 @@ class TAReader(HDF5Reader):
                       ('version', np.uint16)
                      ])
 
-    def __init__(self, filename: str, verbosity: int = 0) -> None:
+    def __init__(self, filename: str, verbosity: int = 0, batch_mode: bool = False) -> None:
         """
         Loads a given HDF5 file.
 
@@ -66,7 +66,7 @@ class TAReader(HDF5Reader):
 
         Returns nothing.
         """
-        super().__init__(filename, verbosity)
+        super().__init__(filename, verbosity, batch_mode)
         self.ta_data = np.array([], dtype=self.ta_dt)
         self.tp_data = []
         return None

--- a/python/trgtools/TCReader.py
+++ b/python/trgtools/TCReader.py
@@ -52,7 +52,7 @@ class TCReader(HDF5Reader):
         ('version', np.uint16)
     ])
 
-    def __init__(self, filename: str, verbosity: int = 0) -> None:
+    def __init__(self, filename: str, verbosity: int = 0, batch_mode: bool = False) -> None:
         """
         Loads a given HDF5 file.
 
@@ -62,7 +62,7 @@ class TCReader(HDF5Reader):
 
         Returns nothing.
         """
-        super().__init__(filename, verbosity)
+        super().__init__(filename, verbosity, batch_mode)
         self.tc_data = np.array([], dtype=self.tc_dt)  # Will concatenate new TCs
         self.ta_data = []  # ta_data[i] will be a np.ndarray of TAs from the i-th TC
         return None

--- a/python/trgtools/TPReader.py
+++ b/python/trgtools/TPReader.py
@@ -38,7 +38,7 @@ class TPReader(HDF5Reader):
                       ('version', np.uint16)
                      ])
 
-    def __init__(self, filename: str, verbosity: int = 0) -> None:
+    def __init__(self, filename: str, verbosity: int = 0, batch_mode: bool = False) -> None:
         """
         Loads a given HDF5 file.
 
@@ -48,7 +48,7 @@ class TPReader(HDF5Reader):
 
         Returns nothing.
         """
-        super().__init__(filename, verbosity)
+        super().__init__(filename, verbosity, batch_mode)
         self.tp_data = np.array([], dtype=self.tp_dt)
         return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib
 numpy
 scipy
 pandas
+tqdm

--- a/scripts/plot_emulated_triggers.py
+++ b/scripts/plot_emulated_triggers.py
@@ -183,8 +183,8 @@ def main():
     # Make the displays
     plot_all_event_displays(tc_reader.tc_data, tc_reader.ta_data, ta_reader.ta_data, ta_reader.tp_data, tc_reader.run_id, tc_reader.file_index, batch)
 
-    print(f"tc data: {tc_reader}: number of tcs: {len(tc_reader.tc_data)}, all the TAs in TCs: {len(np.concatenate(tc_reader.ta_data))}")
-    print(f"ta data: {ta_reader} number of TAs using tp data: {len(ta_reader.tp_data)}")
+    print(f"From TCReader: number of TCs: {len(tc_reader.tc_data)}, all the TAs in TCs: {len(np.concatenate(tc_reader.ta_data))}")
+    print(f"From TAReader: number of TAs: {len(ta_reader.tp_data)}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/plot_emulated_triggers.py
+++ b/scripts/plot_emulated_triggers.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+
+"""
+"""
+
+import trgtools
+from trgtools.plot import PDFPlotter
+
+import trgdataformats
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib as mtp
+import pandas as pd
+from matplotlib.collections import PatchCollection
+from matplotlib.backends.backend_pdf import PdfPages
+from scipy import stats
+from tqdm import tqdm
+
+import argparse
+import os
+
+
+ALGORITHM_LABELS = list(trgdataformats.TriggerCandidateData.Algorithm.__members__.keys())
+ALGORITHM_TICKS = [tp_alg.value for tp_alg in trgdataformats.TriggerCandidateData.Algorithm.__members__.values()]
+TYPE_LABELS = list(trgdataformats.TriggerCandidateData.Type.__members__.keys())
+TYPE_TICKS = [tp_type.value for tp_type in trgdataformats.TriggerCandidateData.Type.__members__.values()]
+
+TICK_TO_SEC_SCALE = 16e-9  # s per tick
+
+def parse():
+    """
+    Parses CLI input arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Display diagnostic information for TCs for a given HDF5 file."
+    )
+    parser.add_argument(
+        "filename",
+        help="Absolute path to tpstream file to display."
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="count",
+        help="Increment the verbose level (errors, warnings, all)."
+        "Save names and skipped writes are always printed. Default: 0.",
+        default=0
+    )
+    parser.add_argument(
+        "--start-frag",
+        type=int,
+        help="Starting fragment index to process from. Takes negative indexing. Default: -10.",
+        default=-10
+    )
+    parser.add_argument(
+        "--end-frag",
+        type=int,
+        help="Fragment index to stop processing (i.e. not inclusive). Takes negative indexing. Default: N.",
+        default=0
+    )
+    parser.add_argument(
+        "--overwrite",
+        type=bool,
+        help="Do you want to overwrite the output plot file, if already exists? Default: False.",
+        default=False
+    )
+
+    return parser.parse_args()
+
+def find_save_name(run_id: int, file_index: int, overwrite: bool) -> str:
+    """
+    Find a new save name or overwrite an existing one.
+
+    Parameters:
+        run_id (int): The run number for the read file.
+        file_index (int): The file index for the run number of the read file.
+        overwrite (bool): Overwrite the 0th plot directory of the same naming.
+
+    Returns:
+        (str): Save name to write as.
+
+    This is missing the file extension. It's the job of the save/write command
+    to append the extension.
+    """
+    # Try to find a new name.
+    name_iter = 0
+    save_name = f"tc_{run_id}-{file_index:04}_figures_{name_iter:04}"
+
+    # Outputs will always create a PDF, so use that as the comparison.
+    while not overwrite and os.path.exists(save_name + ".pdf"):
+        name_iter += 1
+        save_name = f"tc_{run_id}-{file_index:04}_figures_{name_iter:04}"
+    print(f"Saving outputs to ./{save_name}.*")
+
+    return save_name
+
+def plot_all_event_displays(tc_data: list[np.ndarray],
+                            tc_data_tas: list[np.ndarray],
+                            ta_data: list[np.ndarray],
+                            ta_data_tps: list[np.ndarray],
+                            run_id: int,
+                            file_index: int) -> None:
+
+    time_unit = "Ticks"
+
+    print("tick 0")
+    with PdfPages(f"event_displays_{run_id}.{file_index:04}.pdf") as pdf:
+        for tcdx, (tc, tas) in tqdm(enumerate(zip(tc_data, tc_data_tas)), total=len(tc_data), desc="Saving event displays"):
+            plt.figure(figsize=(6, 4))
+
+            yend = tc["time_end"] - tc["time_start"]
+            ta_times_starts = tas['time_start'] - tc["time_start"]
+            ta_times_ends = tas['time_end'] - tc["time_start"] 
+
+            channel_start = np.min(tas['channel_start'])
+            channel_end = np.max(tas['channel_end'])
+
+            # Only change the xlim if there is more than one TP.
+            yexpansion = yend * 0.05
+            xexpansion = (channel_end - channel_start) * 0.05
+
+            plt.ylim(0 - xexpansion, yend + xexpansion)
+            plt.xlim(channel_start - yexpansion, channel_end + yexpansion)
+
+            currentAxis = plt.gca()
+            for tadx, ta in enumerate(tas):
+                rectangle = mtp.patches.Rectangle((ta['channel_start'], ta_times_starts[tadx]), ta['channel_end'] - ta['channel_start'],  ta_times_ends[tadx] - ta_times_starts[tadx], linewidth=1, edgecolor='r', facecolor='none')
+                currentAxis.add_patch(rectangle)
+
+                for tatmpdx, tatmp in enumerate(ta_data):
+                    if (tatmp['time_start'] == ta['time_start']) and (tatmp['time_end'] == ta['time_end']) and (tatmp['channel_start'] == ta['channel_start']) and (tatmp['channel_end'] == ta['channel_end']):
+                        time_starts = ta_data_tps[tatmpdx]['time_start'] - tc["time_start"]
+                        plt.scatter(ta_data_tps[tatmpdx]['channel'], time_starts, lw=0, color='black', marker=',', s=1)
+
+            plt.title(f'Run {run_id}.{file_index:04} Event Display: {tadx:03}')
+            plt.ylabel(f"Relative Start Time ({time_unit})")
+            plt.xlabel("Channel")
+            plt.ylim(0 - xexpansion, yend + xexpansion)
+            plt.xlim(channel_start - yexpansion, channel_end + yexpansion)
+
+            plt.tight_layout()
+            pdf.savefig()
+            plt.close()
+
+def main():
+    args = parse()
+    filename = args.filename
+    verbosity = args.verbose
+    #start_frag = args.start_frag
+    #end_frag = args.end_frag
+    overwrite = args.overwrite
+
+    # Getting the ta data
+    ta_reader = trgtools.TAReader(filename, verbosity)
+    ta_reader.read_all_fragments()
+
+    # Getting the tc data
+    tc_reader = trgtools.TCReader(filename, verbosity)
+    tc_reader.read_all_fragments()
+
+    # Create the output file
+    save_name = find_save_name(tc_reader.run_id, tc_reader.file_index, overwrite)
+    pdf_plotter = PDFPlotter(f"{save_name}.pdf")
+    pdf = pdf_plotter.get_pdf()  # Needed for extra plots that are not general.
+
+    # Make the displays
+    plot_all_event_displays(tc_reader.tc_data, tc_reader.ta_data, ta_reader.ta_data, ta_reader.tp_data, tc_reader.run_id, tc_reader.file_index)
+
+    print(f"tc data: {tc_reader}: number of tcs: {len(tc_reader.tc_data)}, all the TAs in TCs: {len(tc_reader.ta_data)}")
+    print(f"ta data: {ta_reader} number of TAs using tp data: {len(ta_reader.tp_data)}")# and ta data: {ta_reader.ta_data}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_emulated_triggers.py
+++ b/scripts/plot_emulated_triggers.py
@@ -68,33 +68,6 @@ def parse():
 
     return parser.parse_args()
 
-def find_save_name(run_id: int, file_index: int, overwrite: bool) -> str:
-    """
-    Find a new save name or overwrite an existing one.
-
-    Parameters:
-        run_id (int): The run number for the read file.
-        file_index (int): The file index for the run number of the read file.
-        overwrite (bool): Overwrite the 0th plot directory of the same naming.
-
-    Returns:
-        (str): Save name to write as.
-
-    This is missing the file extension. It's the job of the save/write command
-    to append the extension.
-    """
-    # Try to find a new name.
-    name_iter = 0
-    save_name = f"tc_{run_id}-{file_index:04}_figures_{name_iter:04}"
-
-    # Outputs will always create a PDF, so use that as the comparison.
-    while not overwrite and os.path.exists(save_name + ".pdf"):
-        name_iter += 1
-        save_name = f"tc_{run_id}-{file_index:04}_figures_{name_iter:04}"
-    print(f"Saving outputs to ./{save_name}.*")
-
-    return save_name
-
 def plot_all_event_displays(tc_data: List[np.ndarray],
                             tc_data_tas: List[np.ndarray],
                             ta_data: List[np.ndarray],
@@ -174,11 +147,6 @@ def main():
     # Getting the tc data
     tc_reader = trgtools.TCReader(filename, verbosity, batch)
     tc_reader.read_all_fragments()
-
-    # Create the output file
-    save_name = find_save_name(tc_reader.run_id, tc_reader.file_index, overwrite)
-    pdf_plotter = PDFPlotter(f"{save_name}.pdf")
-    pdf = pdf_plotter.get_pdf()  # Needed for extra plots that are not general.
 
     # Make the displays
     plot_all_event_displays(tc_reader.tc_data, tc_reader.ta_data, ta_reader.ta_data, ta_reader.tp_data, tc_reader.run_id, tc_reader.file_index, batch)

--- a/scripts/plot_emulated_triggers.py
+++ b/scripts/plot_emulated_triggers.py
@@ -99,9 +99,6 @@ def plot_all_event_displays(tc_data: list[NDArray],
             yexpansion = yend * 0.05
             xexpansion = (channel_end - channel_start) * 0.05
 
-            plt.ylim(0 - xexpansion, yend + xexpansion)
-            plt.xlim(channel_start - yexpansion, channel_end + yexpansion)
-
             currentAxis = plt.gca()
             for tadx, ta in enumerate(tas):
                 rectangle = mtp.patches.Rectangle((ta['channel_start'], ta_times_starts[tadx]), ta['channel_end'] - ta['channel_start'],  ta_times_ends[tadx] - ta_times_starts[tadx], linewidth=1, edgecolor='r', facecolor='none')
@@ -115,8 +112,8 @@ def plot_all_event_displays(tc_data: list[NDArray],
             plt.title(f'Run {run_id}.{file_index:04} Event Display: {tcdx:03}')
             plt.ylabel(f"Relative Start Time ({time_unit})")
             plt.xlabel("Channel")
-            plt.ylim(0 - xexpansion, yend + xexpansion)
-            plt.xlim(channel_start - yexpansion, channel_end + yexpansion)
+            plt.ylim(0 - yexpansion, yend + yexpansion)
+            plt.xlim(channel_start - xexpansion, channel_end + xexpansion)
 
             plt.tight_layout()
             pdf.savefig()

--- a/scripts/plot_emulated_triggers.py
+++ b/scripts/plot_emulated_triggers.py
@@ -15,21 +15,12 @@ import trgdataformats
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mtp
-import pandas as pd
-from matplotlib.collections import PatchCollection
 from matplotlib.backends.backend_pdf import PdfPages
 from scipy import stats
 from tqdm import tqdm
 
 import argparse
 import os
-
-ALGORITHM_LABELS = list(trgdataformats.TriggerCandidateData.Algorithm.__members__.keys())
-ALGORITHM_TICKS = [tp_alg.value for tp_alg in trgdataformats.TriggerCandidateData.Algorithm.__members__.values()]
-TYPE_LABELS = list(trgdataformats.TriggerCandidateData.Type.__members__.keys())
-TYPE_TICKS = [tp_type.value for tp_type in trgdataformats.TriggerCandidateData.Type.__members__.values()]
-
-TICK_TO_SEC_SCALE = 16e-9  # s per tick
 
 def parse():
     """
@@ -66,9 +57,13 @@ def parse():
     )
     parser.add_argument(
         "--overwrite",
-        type=bool,
+        action="store_true",
         help="Do you want to overwrite the output plot file, if already exists? (Default: False)",
-        default=False
+    )
+    parser.add_argument(
+        "--batch", "-b",
+        action="store_true",
+        help="Do you want to run in batch mode (e.g. without loading bars/tqdm)?"
     )
 
     return parser.parse_args()
@@ -105,7 +100,8 @@ def plot_all_event_displays(tc_data: List[np.ndarray],
                             ta_data: List[np.ndarray],
                             ta_data_tps: List[np.ndarray],
                             run_id: int,
-                            file_index: int) -> None:
+                            file_index: int,
+                            batch: bool) -> None:
     """
 
     Plots all the event displays, one per TC.
@@ -125,7 +121,7 @@ def plot_all_event_displays(tc_data: List[np.ndarray],
     time_unit = "Ticks"
 
     with PdfPages(f"event_displays_{run_id}.{file_index:04}.pdf") as pdf:
-        for tcdx, (tc, tas) in tqdm(enumerate(zip(tc_data, tc_data_tas)), total=len(tc_data), desc="Saving event displays"):
+        for tcdx, (tc, tas) in tqdm(enumerate(zip(tc_data, tc_data_tas)), total=len(tc_data), desc="Saving event displays", disable=batch):
             plt.figure(figsize=(6, 4))
 
             yend = tc["time_end"] - tc["time_start"]
@@ -169,13 +165,14 @@ def main():
     #start_frag = args.start_frag
     #end_frag = args.end_frag
     overwrite = args.overwrite
+    batch = args.batch
 
     # Getting the ta data
-    ta_reader = trgtools.TAReader(filename, verbosity)
+    ta_reader = trgtools.TAReader(filename, verbosity, batch)
     ta_reader.read_all_fragments()
 
     # Getting the tc data
-    tc_reader = trgtools.TCReader(filename, verbosity)
+    tc_reader = trgtools.TCReader(filename, verbosity, batch)
     tc_reader.read_all_fragments()
 
     # Create the output file
@@ -184,10 +181,10 @@ def main():
     pdf = pdf_plotter.get_pdf()  # Needed for extra plots that are not general.
 
     # Make the displays
-    plot_all_event_displays(tc_reader.tc_data, tc_reader.ta_data, ta_reader.ta_data, ta_reader.tp_data, tc_reader.run_id, tc_reader.file_index)
+    plot_all_event_displays(tc_reader.tc_data, tc_reader.ta_data, ta_reader.ta_data, ta_reader.tp_data, tc_reader.run_id, tc_reader.file_index, batch)
 
-    print(f"tc data: {tc_reader}: number of tcs: {len(tc_reader.tc_data)}, all the TAs in TCs: {len(tc_reader.ta_data)}")
-    print(f"ta data: {ta_reader} number of TAs using tp data: {len(ta_reader.tp_data)}")# and ta data: {ta_reader.ta_data}")
+    print(f"tc data: {tc_reader}: number of tcs: {len(tc_reader.tc_data)}, all the TAs in TCs: {len(np.concatenate(tc_reader.ta_data))}")
+    print(f"ta data: {ta_reader} number of TAs using tp data: {len(ta_reader.tp_data)}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/plot_emulated_triggers.py
+++ b/scripts/plot_emulated_triggers.py
@@ -8,7 +8,7 @@ for a given tpstream file
 import trgtools
 from trgtools.plot import PDFPlotter
 
-from types import Dict, List
+from typing import Dict, List
 
 import trgdataformats
 
@@ -23,7 +23,6 @@ from tqdm import tqdm
 
 import argparse
 import os
-
 
 ALGORITHM_LABELS = list(trgdataformats.TriggerCandidateData.Algorithm.__members__.keys())
 ALGORITHM_TICKS = [tp_alg.value for tp_alg in trgdataformats.TriggerCandidateData.Algorithm.__members__.values()]

--- a/scripts/plot_emulated_triggers.py
+++ b/scripts/plot_emulated_triggers.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 
 """
+Plot the trigger candidates, with their trigger activities & trigger primitives
+for a given tpstream file
 """
 
 import trgtools
 from trgtools.plot import PDFPlotter
+
+from types import Dict, List
 
 import trgdataformats
 
@@ -31,6 +35,9 @@ TICK_TO_SEC_SCALE = 16e-9  # s per tick
 def parse():
     """
     Parses CLI input arguments.
+
+    Returns:
+        (Dict(str, Any)): A dictionary of argument names vs argument values
     """
     parser = argparse.ArgumentParser(
         description="Display diagnostic information for TCs for a given HDF5 file."
@@ -49,19 +56,19 @@ def parse():
     parser.add_argument(
         "--start-frag",
         type=int,
-        help="Starting fragment index to process from. Takes negative indexing. Default: -10.",
+        help="Starting fragment index to process from. Takes negative indexing (Default: -10), NOT SUPPORTED YET).",
         default=-10
     )
     parser.add_argument(
         "--end-frag",
         type=int,
-        help="Fragment index to stop processing (i.e. not inclusive). Takes negative indexing. Default: N.",
+        help="Fragment index to stop processing (i.e. not inclusive). Takes negative indexing (Default: N(0), NOT SUPPORTED YET).",
         default=0
     )
     parser.add_argument(
         "--overwrite",
         type=bool,
-        help="Do you want to overwrite the output plot file, if already exists? Default: False.",
+        help="Do you want to overwrite the output plot file, if already exists? (Default: False)",
         default=False
     )
 
@@ -94,16 +101,30 @@ def find_save_name(run_id: int, file_index: int, overwrite: bool) -> str:
 
     return save_name
 
-def plot_all_event_displays(tc_data: list[np.ndarray],
-                            tc_data_tas: list[np.ndarray],
-                            ta_data: list[np.ndarray],
-                            ta_data_tps: list[np.ndarray],
+def plot_all_event_displays(tc_data: List[np.ndarray],
+                            tc_data_tas: List[np.ndarray],
+                            ta_data: List[np.ndarray],
+                            ta_data_tps: List[np.ndarray],
                             run_id: int,
                             file_index: int) -> None:
+    """
+
+    Plots all the event displays, one per TC.
+
+    Each event display will contain TriggerActivities (red boxes), and
+    TriggerPrimitives (black points) for each TriggerActivity.
+
+    Args:
+        tc_data (List[np.ndarray]): A list of TriggerCandidates
+        tc_data_tas (List[np.ndarray]): A list of TriggerActivityData per TriggerCandidate
+        ta_data (List[np.ndarray]): A full list of TriggerActivities
+        ta_data_tps (List[np.ndarray]): A list of TriggerPrimitives per TriggerActivity
+        run_id (int): Run ID number
+        file_index (int): File index
+    """
 
     time_unit = "Ticks"
 
-    print("tick 0")
     with PdfPages(f"event_displays_{run_id}.{file_index:04}.pdf") as pdf:
         for tcdx, (tc, tas) in tqdm(enumerate(zip(tc_data, tc_data_tas)), total=len(tc_data), desc="Saving event displays"):
             plt.figure(figsize=(6, 4))

--- a/scripts/plot_emulated_triggers.py
+++ b/scripts/plot_emulated_triggers.py
@@ -6,28 +6,24 @@ for a given tpstream file
 """
 
 import trgtools
-from trgtools.plot import PDFPlotter
 
-from typing import Dict, List
-
-import trgdataformats
+from typing import Any
+from numpy.typing import NDArray
 
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mtp
 from matplotlib.backends.backend_pdf import PdfPages
-from scipy import stats
 from tqdm import tqdm
 
 import argparse
-import os
 
-def parse():
+def parse() -> dict[str, Any]:
     """
     Parses CLI input arguments.
 
     Returns:
-        (Dict(str, Any)): A dictionary of argument names vs argument values
+        (dict[str, Any]): A dictionary of argument names vs argument values
     """
     parser = argparse.ArgumentParser(
         description="Display diagnostic information for TCs for a given HDF5 file."
@@ -56,11 +52,6 @@ def parse():
         default=0
     )
     parser.add_argument(
-        "--overwrite",
-        action="store_true",
-        help="Do you want to overwrite the output plot file, if already exists? (Default: False)",
-    )
-    parser.add_argument(
         "--batch", "-b",
         action="store_true",
         help="Do you want to run in batch mode (e.g. without loading bars/tqdm)?"
@@ -68,10 +59,10 @@ def parse():
 
     return parser.parse_args()
 
-def plot_all_event_displays(tc_data: List[np.ndarray],
-                            tc_data_tas: List[np.ndarray],
-                            ta_data: List[np.ndarray],
-                            ta_data_tps: List[np.ndarray],
+def plot_all_event_displays(tc_data: list[NDArray],
+                            tc_data_tas: list[NDArray],
+                            ta_data: list[NDArray],
+                            ta_data_tps: list[NDArray],
                             run_id: int,
                             file_index: int,
                             batch: bool) -> None:
@@ -83,10 +74,10 @@ def plot_all_event_displays(tc_data: List[np.ndarray],
     TriggerPrimitives (black points) for each TriggerActivity.
 
     Args:
-        tc_data (List[np.ndarray]): A list of TriggerCandidates
-        tc_data_tas (List[np.ndarray]): A list of TriggerActivityData per TriggerCandidate
-        ta_data (List[np.ndarray]): A full list of TriggerActivities
-        ta_data_tps (List[np.ndarray]): A list of TriggerPrimitives per TriggerActivity
+        tc_data (list[NDArray]): A list of TriggerCandidates
+        tc_data_tas (list[NDArray]): A list of TriggerActivityData per TriggerCandidate
+        ta_data (list[NDArray]): A full list of TriggerActivities
+        ta_data_tps (list[NDArray]): A list of TriggerPrimitives per TriggerActivity
         run_id (int): Run ID number
         file_index (int): File index
     """
@@ -121,7 +112,7 @@ def plot_all_event_displays(tc_data: List[np.ndarray],
                         time_starts = ta_data_tps[tatmpdx]['time_start'] - tc["time_start"]
                         plt.scatter(ta_data_tps[tatmpdx]['channel'], time_starts, lw=0, color='black', marker=',', s=1)
 
-            plt.title(f'Run {run_id}.{file_index:04} Event Display: {tadx:03}')
+            plt.title(f'Run {run_id}.{file_index:04} Event Display: {tcdx:03}')
             plt.ylabel(f"Relative Start Time ({time_unit})")
             plt.xlabel("Channel")
             plt.ylim(0 - xexpansion, yend + xexpansion)
@@ -137,7 +128,6 @@ def main():
     verbosity = args.verbose
     #start_frag = args.start_frag
     #end_frag = args.end_frag
-    overwrite = args.overwrite
     batch = args.batch
 
     # Getting the ta data

--- a/scripts/ta_dump.py
+++ b/scripts/ta_dump.py
@@ -261,6 +261,11 @@ def parse():
         action="store_true",
         help="Overwrite old outputs. Default: False."
     )
+    parser.add_argument(
+        "--batch-mode", "-b",
+        action="store_true",
+        help="Do you want to run in the batch mode (without loading bars/tqdm)?"
+    )
 
     return parser.parse_args()
 
@@ -279,6 +284,7 @@ def main():
     no_anomaly = args.no_anomaly
     seconds = args.seconds
     overwrite = args.overwrite
+    batch_mode = args.batch_mode
 
     linear = args.linear
     log = args.log
@@ -288,7 +294,7 @@ def main():
         linear = True
         log = True
 
-    data = trgtools.TAReader(filename, verbosity)
+    data = trgtools.TAReader(filename, verbosity, batch_mode)
 
     # Check that there are TA fragments.
     if len(data.get_fragment_paths()) == 0:

--- a/scripts/tc_dump.py
+++ b/scripts/tc_dump.py
@@ -255,6 +255,11 @@ def parse():
         action="store_true",
         help="Overwrite old outputs. Default: False."
     )
+    parser.add_argument(
+        "--batch_mode", "-b",
+        action="store_true",
+        help="Do you want to run in batch mode (without loading bars/tqdm)?"
+    )
 
     return parser.parse_args()
 
@@ -272,6 +277,7 @@ def main():
     no_anomaly = args.no_anomaly
     seconds = args.seconds
     overwrite = args.overwrite
+    batch_mode = args.batch_mode
 
     linear = args.linear
     log = args.log
@@ -281,7 +287,7 @@ def main():
         linear = True
         log = True
 
-    data = trgtools.TCReader(filename, verbosity)
+    data = trgtools.TCReader(filename, verbosity, batch_mode)
 
     # Check that there are TC fragments.
     if len(data.get_fragment_paths()) == 0:

--- a/scripts/tp_dump.py
+++ b/scripts/tp_dump.py
@@ -234,6 +234,11 @@ def parse():
         action="store_true",
         help="Overwrite old outputs. Default: False."
     )
+    parser.add_argument(
+        "--batch-mode", "-b",
+        action="store_true",
+        help="Do you want to run in batch mode (without loading bars/tqdm)?"
+    )
 
     return parser.parse_args()
 
@@ -251,6 +256,7 @@ def main():
     no_anomaly = args.no_anomaly
     seconds = args.seconds
     overwrite = args.overwrite
+    batch_mode = args.batch_mode
 
     linear = args.linear
     log = args.log
@@ -260,7 +266,7 @@ def main():
         linear = True
         log = True
 
-    data = trgtools.TPReader(filename, verbosity)
+    data = trgtools.TPReader(filename, verbosity, batch_mode)
 
     # Check that there are TP fragments.
     if len(data.get_fragment_paths()) == 0:

--- a/src/TAFileHandler.cpp
+++ b/src/TAFileHandler.cpp
@@ -103,6 +103,7 @@ TAFileHandler::get_sourceid_geoid_map()
 void TAFileHandler::worker_thread()
 {
   while (true) {
+    /// Get a task from the queue (with locking)
     std::function<void()> task;
     {
       std::unique_lock<std::mutex> lock(m_queue_mutex);
@@ -132,8 +133,9 @@ void TAFileHandler::worker_thread()
 
 void TAFileHandler::process_tasks()
 {
-  // std::set of record IDs (pair of record number & sequence number)
+  // Iterate over the input files
   for (auto& input_file: m_input_files) {
+    // std::set of record IDs (pair of record number & sequence number)
     auto records = input_file->get_all_record_ids();
 
     for (const auto& record : records) {
@@ -143,10 +145,11 @@ void TAFileHandler::process_tasks()
         continue;
       }
 
+      // Get all the fragments
       daqdataformats::TimeSlice timeslice = input_file->get_timeslice(record);
-
       const auto& fragments = timeslice.get_fragments_ref();
 
+      // Iterate over the fragments & process each fragment
       for (const auto& fragment : fragments) {
         daqdataformats::SourceID sid = fragment->get_element_id();
 
@@ -182,6 +185,7 @@ void TAFileHandler::process_tasks()
         // Customise the source id (add 1000 to id)
         frag_hdr.element_id = daqdataformats::SourceID{daqdataformats::SourceID::Subsystem::kTrigger, fragment->get_element_id().id+1000};
 
+        // Either enqueue the task if using parallel processing, or execute the task now
         if (m_run_parallel) {
           enqueue_task([this, sid, record, frag_hdr, tp_buffer = std::move(tp_buffer)]() mutable {
             this->process_task(sid, record.first, frag_hdr, std::move(tp_buffer));
@@ -191,6 +195,8 @@ void TAFileHandler::process_tasks()
           this->process_task(sid, record.first, frag_hdr, std::move(tp_buffer));
         }
       }
+      // If running in parallel, wait to process entire slice before we move to
+      // the next one
       if (m_run_parallel) {
         wait_to_complete_tasks();
       }
@@ -228,9 +234,11 @@ void TAFileHandler::wait_to_complete_tasks()
 
 void TAFileHandler::wait_to_complete_work()
 {
+  // Wait for the main threads to join
   m_main_thread.join();
   fmt::print("TAFileHandler_{} work completed\n", m_id);
 
+  // Wait for the tasks to complete
   if (m_run_parallel) {
     wait_to_complete_tasks();
 
@@ -252,13 +260,18 @@ void TAFileHandler::process_task(daqdataformats::SourceID _source_id,
                                  daqdataformats::FragmentHeader _header,
                                  std::vector<trgdataformats::TriggerPrimitive>&& _tps)
 {
+  // Get te last fragment
   std::unique_ptr<daqdataformats::Fragment> frag = m_ta_emulators[_source_id]->emulate_vector(_tps);
+  j
+  // Don't do anything if no fragments found
   if (!frag) {
     return;
   }
 
+  // Get all the TriggerActivities from the TA Emulator buffer
   std::vector<triggeralgs::TriggerActivity> ta_buffer = m_ta_emulators[_source_id]->get_last_output_buffer();
 
+  // Don't continue if no TAs found
   size_t n_tas = ta_buffer.size();
   if (!n_tas) {
     return;
@@ -268,6 +281,7 @@ void TAFileHandler::process_task(daqdataformats::SourceID _source_id,
     fmt::print(" Found {} TAs!\n", n_tas);
   }
 
+  // Set the fragment header & push into our output (with locking!)
   {
     if (m_run_parallel) {
       std::lock_guard<std::mutex> lock(m_savetps_mutex);
@@ -295,4 +309,4 @@ std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> TAFil
 
 }; // namespace dunedaq::trgtools
 
-#endif //TRGTOOLS_TAFILEHANDLER_HXX_
+#endif //TRGTOOLS_TAFILEHANDLER_CXX_

--- a/src/TAFileHandler.cpp
+++ b/src/TAFileHandler.cpp
@@ -262,7 +262,7 @@ void TAFileHandler::process_task(daqdataformats::SourceID _source_id,
 {
   // Get te last fragment
   std::unique_ptr<daqdataformats::Fragment> frag = m_ta_emulators[_source_id]->emulate_vector(_tps);
-  j
+
   // Don't do anything if no fragments found
   if (!frag) {
     return;

--- a/src/TAFileHandler.cpp
+++ b/src/TAFileHandler.cpp
@@ -6,17 +6,16 @@
 namespace dunedaq::trgtools 
 {
 
-TAFileHandler::TAFileHandler(std::string input_path, nlohmann::json config, size_t n_threads)
-  : m_input_path(input_path), m_num_threads(n_threads)
+TAFileHandler::TAFileHandler(std::string input_path, nlohmann::json config, std::pair<uint64_t, uint64_t> sliceid_range)
+  : m_input_paths({input_path}), m_sliceid_range(sliceid_range), m_id(m_id_next++)
 {
   std::string algo_name = config["trigger_activity_plugin"][0];
   nlohmann::json algo_config = config["trigger_activity_config"][0];
 
   // Get the input file
-  m_input_file = std::make_unique<hdf5libs::HDF5RawDataFile>(input_path);
+  m_input_file = std::make_unique<hdf5libs::HDF5RawDataFile>(m_input_paths[0]);
   if (!m_input_file->is_timeslice_type()) {
-    fmt::print("ERROR: input file '{}' not of type 'TimeSlice'\n", input_path);
-    throw std::runtime_error(fmt::format("ERROR: input file '{}' not of type 'TimeSlice'", input_path));
+    throw std::runtime_error(fmt::format("ERROR: input file '{}' not of type 'TimeSlice'", m_input_paths[0]));
   }
 
   // Extract the run number etc
@@ -36,48 +35,60 @@ TAFileHandler::TAFileHandler(std::string input_path, nlohmann::json config, size
   fmt::print("Number of makers to make: {}\n", makers_to_make);
 
   for (size_t i = 0; i < makers_to_make; ++i) {
+    // Create TAMaker
     std::unique_ptr<triggeralgs::TriggerActivityMaker> ta_maker =
       triggeralgs::TriggerActivityFactory::get_instance()->build_maker(algo_name);
     ta_maker->configure(algo_config);
+
+    // Add it to the enulators
     m_ta_emulators.push_back(std::make_unique<trgtools::EmulateTAUnit>());
     m_ta_emulators.back()->set_maker(ta_maker);
-  }
 
-  if (m_num_threads == 0) {
-    m_num_threads = makers_to_make;
-  }
-  for (size_t i = 0; i < m_num_threads; ++i) {
-    m_thread_pool.emplace_back(&TAFileHandler::worker_thread, this);
+    // Create a worker thread per emulator
+    //m_thread_pool.emplace_back(&TAFileHandler::worker_thread, this);
   }
 }
 
-void TAFileHandler::worker_thread()
+hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t
+TAFileHandler::get_sourceid_geoid_map()
 {
-  while (true) {
-    std::function<void()> task;
-    {
-      std::unique_lock<std::mutex> lock(m_queue_mutex);
-      m_condition.wait(lock, [this]() {return m_stop || !m_task_queue.empty(); });
-
-      if (m_stop && m_task_queue.empty()) {
-        return;
-      }
-
-      task = std::move(m_task_queue.front());
-      m_task_queue.pop();
-    }
-
-    task();
-
-    {
-      std::lock_guard<std::mutex> lock(m_queue_mutex);
-      --m_active_tasks;
-      if (m_active_tasks == 0) {
-        m_task_complete_condition.notify_all();
-      }
-    }
+  if (!m_input_file) {
+    throw "File not set yet!";
   }
+
+  return m_input_file->get_srcid_geoid_map();
+
 }
+
+//void TAFileHandler::worker_thread()
+//{
+//  while (true) {
+//    std::function<void()> task;
+//    {
+//      std::unique_lock<std::mutex> lock(m_queue_mutex);
+//      m_condition.wait(lock, [this]() {return m_stop || !m_task_queue.empty(); });
+//
+//      if (m_stop && m_task_queue.empty()) {
+//        return;
+//      }
+//
+//      task = std::move(m_task_queue.front());
+//      m_task_queue.pop();
+//    }
+//
+//    // Run & complete a task
+//    task();
+//
+//    // Notify that task was completed
+//    {
+//      std::lock_guard<std::mutex> lock(m_queue_mutex);
+//      --m_active_tasks;
+//      if (m_active_tasks == 0) {
+//        m_task_complete_condition.notify_all();
+//      }
+//    }
+//  }
+//}
 
 void TAFileHandler::process_tasks(uint64_t time, bool quiet)
 {
@@ -85,6 +96,12 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
   auto records = m_input_file->get_all_record_ids();
 
   for (const auto& record : records) {
+    if (record.first < m_sliceid_range.first || record.first > m_sliceid_range.second) {
+      if (!quiet)
+        fmt::print("  Will not process RecordID {} because it's outside of our range!", record.first);
+      continue;
+    }
+
     daqdataformats::TimeSlice timeslice = m_input_file->get_timeslice(record);
 
     const auto& fragments = timeslice.get_fragments_ref();
@@ -92,13 +109,15 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
     size_t frags_size = fragments.size();
     for (size_t i = 0; i < frags_size; ++i) {
       const auto& fragment = fragments[i];
+
       if (fragment->get_element_id().subsystem != daqdataformats::SourceID::Subsystem::kTrigger) {
         if (!quiet)
           fmt::print("  Warning, got non kTrigger SourceID {}\n", fragment->get_element_id().to_string());
         continue;
       }
 
-      if (fragment->get_fragment_type() != daqdataformats::FragmentType::kTriggerPrimitive) {
+      if (fragment->get_fragment_type() !=
+          daqdataformats::FragmentType::kTriggerPrimitive) {
         if (!quiet)
           fmt::print("  Error: FragmentType is: {}!\n", dunedaq::daqdataformats::fragment_type_to_string(fragment->get_fragment_type()));
         continue;
@@ -127,68 +146,116 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
         tp_buffer.push_back(tp);
       }
 
-      enqueue_task([this, i, record, tp_buffer = std::move(tp_buffer), time, quiet]() {
-          this->process_task(i, record.first, tp_buffer, time, quiet);
-          });
+      daqdataformats::FragmentHeader frag_hdr = fragment->get_header();
 
+      // Customise the source id (add 1000 to id)
+      frag_hdr.element_id = daqdataformats::SourceID{daqdataformats::SourceID::Subsystem::kTrigger, fragment->get_element_id().id+1000};
+
+      this->process_task(i, record.first, frag_hdr, tp_buffer, time, quiet);
+      //enqueue_task([this, i, record, frag_hdr, tp_buffer = std::move(tp_buffer), time, quiet]() {
+       //   this->process_task(i, record.first, frag_hdr, tp_buffer, time, quiet);
+       //   });
     }
-    wait_to_complete_tasks();
+    //wait_to_complete_tasks();
   }
-};
+  size_t total = 0;
+  for (auto& [key, vec_tas]: m_tas) {
+    total += vec_tas.size();
+  }
+  std::cout << "We have a total of " << total << " TAs!" << std::endl;
+}
 
 void TAFileHandler::start_processing(uint64_t time, bool quiet)
 {
   m_main_thread = std::thread(&TAFileHandler::process_tasks, this, time, quiet);
-};
-
-
-void TAFileHandler::enqueue_task(std::function<void()> task)
-{
-  {
-    std::lock_guard<std::mutex> lock(m_queue_mutex);
-    m_task_queue.push(std::move(task));
-    ++m_active_tasks;
-  }
-  m_condition.notify_one();
 }
 
-void TAFileHandler::wait_to_complete_tasks()
-{
-  std::unique_lock<std::mutex> lock(m_queue_mutex);
-  m_task_complete_condition.wait(lock, [this]() { return m_active_tasks == 0; });
-}
+
+//void TAFileHandler::enqueue_task(std::function<void()> task)
+//{
+//  {
+//    std::lock_guard<std::mutex> lock(m_queue_mutex);
+//    m_task_queue.push(std::move(task));
+//    ++m_active_tasks;
+//  }
+//  m_condition.notify_one();
+//}
+
+//void TAFileHandler::wait_to_complete_tasks()
+//{
+//  std::unique_lock<std::mutex> lock(m_queue_mutex);
+//  m_task_complete_condition.wait(lock, [this]() { return m_active_tasks == 0; });
+//}
 
 void TAFileHandler::wait_to_complete_work()
 {
-  std::cout << "Trying to complete work!\n";
   m_main_thread.join();
-  std::cout << "Main thread joined...\n";
+  fmt::print("TAFileHandler_{} work completed\n", m_id);
 
-  wait_to_complete_tasks();
+  //wait_to_complete_tasks();
 
-  {
-    std::lock_guard<std::mutex> lock(m_queue_mutex);
-    m_stop = true;
-  }
+  //{
+  //  std::lock_guard<std::mutex> lock(m_queue_mutex);
+  //  m_stop = true;
+  //}
   m_condition.notify_all();
 
-  std::cout << "m_stop issued\n";
-  for (std::thread& thread : m_thread_pool) {
-    thread.join();
+  //fmt::print("m_stop issued\n");
+  //for (std::thread& thread : m_thread_pool) {
+  //  thread.join();
+  //}
+}
+
+void TAFileHandler::process_task(int _thread_id,
+                                 uint64_t _rec,
+                                 daqdataformats::FragmentHeader _header,
+                                 std::vector<trgdataformats::TriggerPrimitive> _tps,
+                                 uint64_t _time,
+                                 bool _quiet)
+{
+  std::unique_ptr<daqdataformats::Fragment> frag = m_ta_emulators[_thread_id]->emulate_vector(_tps);
+  if (!frag) {
+    return;
+  }
+
+  std::vector<triggeralgs::TriggerActivity> ta_buffer = m_ta_emulators[_thread_id]->get_last_output_buffer();
+
+  size_t n_tas = ta_buffer.size();
+  if (!n_tas) {
+    return;
+  }
+
+  if (!_quiet && n_tas) {
+    fmt::print(" Found {} TAs!\n", n_tas);
+  }
+
+  if (!_quiet) {
+    fmt::print(" FILE: {} plane: {} completed!\n", m_input_paths[0], _thread_id);
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(m_savetps_mutex);
+    m_tas[_rec].reserve(m_tas[_rec].size() + ta_buffer.size());
+    m_tas[_rec].insert(m_tas[_rec].end(), std::make_move_iterator(ta_buffer.begin()), std::make_move_iterator(ta_buffer.end()));
+
+    frag->set_header_fields(_header);
+    frag->set_type(daqdataformats::FragmentType::kTriggerActivity);
+
+    m_ta_fragments[_rec].push_back(std::move(frag));
   }
 }
 
-void TAFileHandler::process_task(int thread_id, uint64_t rec, std::vector<trgdataformats::TriggerPrimitive> tps, uint64_t time, bool quiet)
+std::map<uint64_t, std::vector<triggeralgs::TriggerActivity>> TAFileHandler::get_tas()
 {
-  std::unique_ptr<daqdataformats::Fragment> tas = m_ta_emulators[thread_id]->emulate_vector(tps);
-  std::vector<triggeralgs::TriggerActivity> ta_buffer = m_ta_emulators[thread_id]->get_last_output_buffer();
+  return std::move(m_tas);
+}
 
-  if (size_t n_tas = ta_buffer.size()) {
-    std::cout << " Found " << n_tas << " TAs!\n";
-  }
+std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> TAFileHandler::get_frags()
+{
+  return std::move(m_ta_fragments);
+}
 
-  std::cout << "FILE: " << m_input_path << " plane: " << thread_id << " rec: " << rec << " completed!\n";
-};
+uint16_t TAFileHandler::m_id_next = 0;
 
 }; // namespace dunedaq::trgtools
 

--- a/src/TAFileHandler.cpp
+++ b/src/TAFileHandler.cpp
@@ -8,12 +8,12 @@ namespace dunedaq::trgtools
 
 uint16_t TAFileHandler::m_id_next = 0;
 
-TAFileHandler::TAFileHandler(std::string input_path,
+TAFileHandler::TAFileHandler(std::vector<std::shared_ptr<hdf5libs::HDF5RawDataFile>> input_files,
                              nlohmann::json config,
                              std::pair<uint64_t, uint64_t> sliceid_range,
                              bool run_parallel,
                              bool quiet)
-  : m_input_paths({input_path}),
+  : m_input_files(input_files),
     m_sliceid_range(sliceid_range),
     m_run_parallel(run_parallel),
     m_quiet(quiet),
@@ -23,25 +23,34 @@ TAFileHandler::TAFileHandler(std::string input_path,
   nlohmann::json algo_config = config["trigger_activity_config"][0];
 
   // Get the input file
-  m_input_file = std::make_unique<hdf5libs::HDF5RawDataFile>(m_input_paths[0]);
-  if (!m_input_file->is_timeslice_type()) {
-    throw std::runtime_error(fmt::format("ERROR: input file '{}' not of type 'TimeSlice'", m_input_paths[0]));
+  // Extract the run number etc
+  std::vector<daqdataformats::run_number_t> run_numbers;
+  std::vector<size_t> file_indices;
+  for (const auto& input_file : input_files) {
+    if (std::find(run_numbers.begin(), run_numbers.end(),
+        input_file->get_attribute<daqdataformats::run_number_t>("run_number")) ==
+        run_numbers.end()) {
+          run_numbers.push_back(input_file->get_attribute<daqdataformats::run_number_t>("run_number"));
+    }
+
+    if (std::find(file_indices.begin(), file_indices.end(),
+        input_file->get_attribute<daqdataformats::run_number_t>("run_number")) ==
+        file_indices.end()) {
+          file_indices.push_back(input_file->get_attribute<size_t>("file_index"));
+    }
   }
 
-  // Extract the run number etc
-  daqdataformats::run_number_t run_number = m_input_file->get_attribute<daqdataformats::run_number_t>("run_number");
-  size_t file_index = m_input_file->get_attribute<size_t>("file_index");
-  std::string application_name = m_input_file->get_attribute<std::string>("application_name");
+  std::string application_name = m_input_files.front()->get_attribute<std::string>("application_name");
 
   if (!m_quiet) {
-    fmt::print("Run Number: {}\nFile Index: {}\nApp name: '{}'\n", run_number, file_index, application_name);
+    fmt::print("Run Numbers: {}\nFile Indices: {}\nApp name: '{}'\n", fmt::join(run_numbers, ","), fmt::join(file_indices, ","), application_name);
   }
 
   // std::set of record IDs (pair of record number & sequence number)
-  auto records = m_input_file->get_all_record_ids();
+  auto records = m_input_files.front()->get_all_record_ids();
 
   // Extract the number of TAMakers to create
-  daqdataformats::TimeSlice first_timeslice = m_input_file->get_timeslice(*records.begin());
+  daqdataformats::TimeSlice first_timeslice = m_input_files.front()->get_timeslice(*records.begin());
   std::vector<daqdataformats::SourceID> valid_sources = get_valid_sourceids(first_timeslice);
   fmt::print("Number of makers to make: {}\n", valid_sources.size());
 
@@ -84,12 +93,11 @@ TAFileHandler::get_valid_sourceids(daqdataformats::TimeSlice& _timeslice)
 hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t
 TAFileHandler::get_sourceid_geoid_map()
 {
-  if (!m_input_file) {
-    throw "File not set yet!";
+  if (!m_input_files.size()) {
+    throw "Files not set yet!";
   }
 
-  return m_input_file->get_srcid_geoid_map();
-
+  return m_input_files.front()->get_srcid_geoid_map();
 }
 
 void TAFileHandler::worker_thread()
@@ -125,76 +133,75 @@ void TAFileHandler::worker_thread()
 void TAFileHandler::process_tasks()
 {
   // std::set of record IDs (pair of record number & sequence number)
-  auto records = m_input_file->get_all_record_ids();
+  for (auto& input_file: m_input_files) {
+    auto records = input_file->get_all_record_ids();
 
-  for (const auto& record : records) {
-    if (record.first < m_sliceid_range.first || record.first > m_sliceid_range.second) {
-      if (!m_quiet)
-        fmt::print("  Will not process RecordID {} because it's outside of our range!", record.first);
-      continue;
-    }
-
-    daqdataformats::TimeSlice timeslice = m_input_file->get_timeslice(record);
-
-    const auto& fragments = timeslice.get_fragments_ref();
-
-    //size_t frags_size = fragments.size();
-    //for (size_t i = 0; i < frags_size; ++i) {
-    //  const auto& fragment = fragments[i];
-    for (const auto& fragment : fragments) {
-      daqdataformats::SourceID sid = fragment->get_element_id();
-
-      if (!m_ta_emulators.contains(sid)) {
+    for (const auto& record : records) {
+      if (record.first < m_sliceid_range.first || record.first > m_sliceid_range.second) {
+        if (!m_quiet)
+          fmt::print("  Will not process RecordID {} because it's outside of our range!", record.first);
         continue;
       }
 
-      // Pull tps out
-      size_t n_tps = fragment->get_data_size()/SIZE_TP;
-      if (!m_quiet) {
-        fmt::print("  TP fragment size: {}\n", fragment->get_data_size());
-        fmt::print("  Num TPs: {}\n", n_tps);
-      }
+      daqdataformats::TimeSlice timeslice = input_file->get_timeslice(record);
 
-      // Create a TP buffer
-      std::vector<trgdataformats::TriggerPrimitive> tp_buffer;
-      // Prepare the TP buffer, checking for time ordering
-      tp_buffer.reserve(n_tps);
+      const auto& fragments = timeslice.get_fragments_ref();
 
-      // Populate the TP buffer
-      trgdataformats::TriggerPrimitive* tp_array = static_cast<trgdataformats::TriggerPrimitive*>(fragment->get_data());
-      uint64_t last_ts = 0;
-      for(size_t tpid(0); tpid<n_tps; ++tpid) {
-        auto& tp = tp_array[tpid];
-        if (tp.time_start <= last_ts && !m_quiet) {
-          fmt::print("  ERROR: {} {} ", tp.time_start, last_ts );
+      for (const auto& fragment : fragments) {
+        daqdataformats::SourceID sid = fragment->get_element_id();
+
+        if (!m_ta_emulators.contains(sid)) {
+          continue;
         }
-        tp_buffer.push_back(tp);
-      }
 
-      daqdataformats::FragmentHeader frag_hdr = fragment->get_header();
+        // Pull tps out
+        size_t n_tps = fragment->get_data_size()/SIZE_TP;
+        if (!m_quiet) {
+          fmt::print("  TP fragment size: {}\n", fragment->get_data_size());
+          fmt::print("  Num TPs: {}\n", n_tps);
+        }
 
-      // Customise the source id (add 1000 to id)
-      frag_hdr.element_id = daqdataformats::SourceID{daqdataformats::SourceID::Subsystem::kTrigger, fragment->get_element_id().id+1000};
+        // Create a TP buffer
+        std::vector<trgdataformats::TriggerPrimitive> tp_buffer;
+        // Prepare the TP buffer, checking for time ordering
+        tp_buffer.reserve(n_tps);
 
-      if (m_run_parallel) {
-        enqueue_task([this, sid, record, frag_hdr, tp_buffer = std::move(tp_buffer)]() mutable {
+        // Populate the TP buffer
+        trgdataformats::TriggerPrimitive* tp_array = static_cast<trgdataformats::TriggerPrimitive*>(fragment->get_data());
+        uint64_t last_ts = 0;
+        for(size_t tpid(0); tpid<n_tps; ++tpid) {
+          auto& tp = tp_array[tpid];
+          if (tp.time_start <= last_ts && !m_quiet) {
+            fmt::print("  ERROR: {} {} ", tp.time_start, last_ts );
+          }
+          tp_buffer.push_back(tp);
+        }
+
+        daqdataformats::FragmentHeader frag_hdr = fragment->get_header();
+
+        // Customise the source id (add 1000 to id)
+        frag_hdr.element_id = daqdataformats::SourceID{daqdataformats::SourceID::Subsystem::kTrigger, fragment->get_element_id().id+1000};
+
+        if (m_run_parallel) {
+          enqueue_task([this, sid, record, frag_hdr, tp_buffer = std::move(tp_buffer)]() mutable {
+            this->process_task(sid, record.first, frag_hdr, std::move(tp_buffer));
+          });
+        }
+        else {
           this->process_task(sid, record.first, frag_hdr, std::move(tp_buffer));
-        });
+        }
       }
-      else {
-        this->process_task(sid, record.first, frag_hdr, std::move(tp_buffer));
+      if (m_run_parallel) {
+        wait_to_complete_tasks();
       }
     }
-    if (m_run_parallel) {
-      wait_to_complete_tasks();
-    }
-  }
 
-  size_t total = 0;
-  for (auto& [key, vec_tas]: m_tas) {
-    total += vec_tas.size();
+    size_t total = 0;
+    for (auto& [key, vec_tas]: m_tas) {
+      total += vec_tas.size();
+    }
+    std::cout << "We have a total of " << total << " TAs!" << std::endl;
   }
-  std::cout << "We have a total of " << total << " TAs!" << std::endl;
 }
 
 void TAFileHandler::start_processing()

--- a/src/TAFileHandler.cpp
+++ b/src/TAFileHandler.cpp
@@ -30,23 +30,43 @@ TAFileHandler::TAFileHandler(std::string input_path, nlohmann::json config, std:
 
   // Extract the number of TAMakers to create
   daqdataformats::TimeSlice first_timeslice = m_input_file->get_timeslice(*records.begin());
-  size_t makers_to_make = first_timeslice.get_fragments_ref().size();
+  std::vector<daqdataformats::SourceID> valid_sources = get_valid_sourceids(first_timeslice);
+  fmt::print("Number of makers to make: {}\n", valid_sources.size());
 
-  fmt::print("Number of makers to make: {}\n", makers_to_make);
-
-  for (size_t i = 0; i < makers_to_make; ++i) {
+  for (const daqdataformats::SourceID& sid : valid_sources) {
     // Create TAMaker
     std::unique_ptr<triggeralgs::TriggerActivityMaker> ta_maker =
       triggeralgs::TriggerActivityFactory::get_instance()->build_maker(algo_name);
     ta_maker->configure(algo_config);
 
     // Add it to the enulators
-    m_ta_emulators.push_back(std::make_unique<trgtools::EmulateTAUnit>());
-    m_ta_emulators.back()->set_maker(ta_maker);
+    m_ta_emulators[sid] = std::make_unique<trgtools::EmulateTAUnit>();
+    m_ta_emulators[sid]->set_maker(ta_maker);
+    //m_ta_emulators.push_back(std::make_unique<trgtools::EmulateTAUnit>());
+    //m_ta_emulators.back()->set_maker(ta_maker);
 
     // Create a worker thread per emulator
     //m_thread_pool.emplace_back(&TAFileHandler::worker_thread, this);
   }
+}
+
+std::vector<daqdataformats::SourceID> 
+TAFileHandler::get_valid_sourceids(daqdataformats::TimeSlice& _timeslice)
+{
+  const auto& fragments = _timeslice.get_fragments_ref();
+
+  std::vector<daqdataformats::SourceID> ret;
+  for (const auto& fragment : fragments) {
+    if (fragment->get_fragment_type() != daqdataformats::FragmentType::kTriggerPrimitive) {
+      continue;
+    }
+
+    daqdataformats::SourceID sourceid = fragment->get_element_id();
+
+    ret.push_back(sourceid);
+  }
+
+  return ret;
 }
 
 hdf5libs::HDF5SourceIDHandler::source_id_geo_id_map_t
@@ -106,20 +126,13 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
 
     const auto& fragments = timeslice.get_fragments_ref();
 
-    size_t frags_size = fragments.size();
-    for (size_t i = 0; i < frags_size; ++i) {
-      const auto& fragment = fragments[i];
+    //size_t frags_size = fragments.size();
+    //for (size_t i = 0; i < frags_size; ++i) {
+    //  const auto& fragment = fragments[i];
+    for (const auto& fragment : fragments) {
+      daqdataformats::SourceID sid = fragment->get_element_id();
 
-      if (fragment->get_element_id().subsystem != daqdataformats::SourceID::Subsystem::kTrigger) {
-        if (!quiet)
-          fmt::print("  Warning, got non kTrigger SourceID {}\n", fragment->get_element_id().to_string());
-        continue;
-      }
-
-      if (fragment->get_fragment_type() !=
-          daqdataformats::FragmentType::kTriggerPrimitive) {
-        if (!quiet)
-          fmt::print("  Error: FragmentType is: {}!\n", dunedaq::daqdataformats::fragment_type_to_string(fragment->get_fragment_type()));
+      if (!m_ta_emulators.contains(sid)) {
         continue;
       }
 
@@ -151,7 +164,7 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
       // Customise the source id (add 1000 to id)
       frag_hdr.element_id = daqdataformats::SourceID{daqdataformats::SourceID::Subsystem::kTrigger, fragment->get_element_id().id+1000};
 
-      this->process_task(i, record.first, frag_hdr, tp_buffer, time, quiet);
+      this->process_task(sid, record.first, frag_hdr, tp_buffer, time, quiet);
       //enqueue_task([this, i, record, frag_hdr, tp_buffer = std::move(tp_buffer), time, quiet]() {
        //   this->process_task(i, record.first, frag_hdr, tp_buffer, time, quiet);
        //   });
@@ -206,19 +219,19 @@ void TAFileHandler::wait_to_complete_work()
   //}
 }
 
-void TAFileHandler::process_task(int _thread_id,
+void TAFileHandler::process_task(daqdataformats::SourceID _source_id,
                                  uint64_t _rec,
                                  daqdataformats::FragmentHeader _header,
                                  std::vector<trgdataformats::TriggerPrimitive> _tps,
                                  uint64_t _time,
                                  bool _quiet)
 {
-  std::unique_ptr<daqdataformats::Fragment> frag = m_ta_emulators[_thread_id]->emulate_vector(_tps);
+  std::unique_ptr<daqdataformats::Fragment> frag = m_ta_emulators[_source_id]->emulate_vector(_tps);
   if (!frag) {
     return;
   }
 
-  std::vector<triggeralgs::TriggerActivity> ta_buffer = m_ta_emulators[_thread_id]->get_last_output_buffer();
+  std::vector<triggeralgs::TriggerActivity> ta_buffer = m_ta_emulators[_source_id]->get_last_output_buffer();
 
   size_t n_tas = ta_buffer.size();
   if (!n_tas) {
@@ -227,10 +240,6 @@ void TAFileHandler::process_task(int _thread_id,
 
   if (!_quiet && n_tas) {
     fmt::print(" Found {} TAs!\n", n_tas);
-  }
-
-  if (!_quiet) {
-    fmt::print(" FILE: {} plane: {} completed!\n", m_input_paths[0], _thread_id);
   }
 
   {

--- a/src/TAFileHandler.cpp
+++ b/src/TAFileHandler.cpp
@@ -6,8 +6,18 @@
 namespace dunedaq::trgtools 
 {
 
-TAFileHandler::TAFileHandler(std::string input_path, nlohmann::json config, std::pair<uint64_t, uint64_t> sliceid_range)
-  : m_input_paths({input_path}), m_sliceid_range(sliceid_range), m_id(m_id_next++)
+uint16_t TAFileHandler::m_id_next = 0;
+
+TAFileHandler::TAFileHandler(std::string input_path,
+                             nlohmann::json config,
+                             std::pair<uint64_t, uint64_t> sliceid_range,
+                             bool run_parallel,
+                             bool quiet)
+  : m_input_paths({input_path}),
+    m_sliceid_range(sliceid_range),
+    m_run_parallel(run_parallel),
+    m_quiet(quiet),
+    m_id(m_id_next++)
 {
   std::string algo_name = config["trigger_activity_plugin"][0];
   nlohmann::json algo_config = config["trigger_activity_config"][0];
@@ -23,7 +33,9 @@ TAFileHandler::TAFileHandler(std::string input_path, nlohmann::json config, std:
   size_t file_index = m_input_file->get_attribute<size_t>("file_index");
   std::string application_name = m_input_file->get_attribute<std::string>("application_name");
 
-  fmt::print("Run Number: {}\nFile Index: {}\nApp name: '{}'\n", run_number, file_index, application_name);
+  if (!m_quiet) {
+    fmt::print("Run Number: {}\nFile Index: {}\nApp name: '{}'\n", run_number, file_index, application_name);
+  }
 
   // std::set of record IDs (pair of record number & sequence number)
   auto records = m_input_file->get_all_record_ids();
@@ -42,11 +54,11 @@ TAFileHandler::TAFileHandler(std::string input_path, nlohmann::json config, std:
     // Add it to the enulators
     m_ta_emulators[sid] = std::make_unique<trgtools::EmulateTAUnit>();
     m_ta_emulators[sid]->set_maker(ta_maker);
-    //m_ta_emulators.push_back(std::make_unique<trgtools::EmulateTAUnit>());
-    //m_ta_emulators.back()->set_maker(ta_maker);
 
     // Create a worker thread per emulator
-    //m_thread_pool.emplace_back(&TAFileHandler::worker_thread, this);
+    if (m_run_parallel) {
+      m_thread_pool.emplace_back(&TAFileHandler::worker_thread, this);
+    }
   }
 }
 
@@ -80,44 +92,44 @@ TAFileHandler::get_sourceid_geoid_map()
 
 }
 
-//void TAFileHandler::worker_thread()
-//{
-//  while (true) {
-//    std::function<void()> task;
-//    {
-//      std::unique_lock<std::mutex> lock(m_queue_mutex);
-//      m_condition.wait(lock, [this]() {return m_stop || !m_task_queue.empty(); });
-//
-//      if (m_stop && m_task_queue.empty()) {
-//        return;
-//      }
-//
-//      task = std::move(m_task_queue.front());
-//      m_task_queue.pop();
-//    }
-//
-//    // Run & complete a task
-//    task();
-//
-//    // Notify that task was completed
-//    {
-//      std::lock_guard<std::mutex> lock(m_queue_mutex);
-//      --m_active_tasks;
-//      if (m_active_tasks == 0) {
-//        m_task_complete_condition.notify_all();
-//      }
-//    }
-//  }
-//}
+void TAFileHandler::worker_thread()
+{
+  while (true) {
+    std::function<void()> task;
+    {
+      std::unique_lock<std::mutex> lock(m_queue_mutex);
+      m_condition.wait(lock, [this]() {return m_stop || !m_task_queue.empty(); });
 
-void TAFileHandler::process_tasks(uint64_t time, bool quiet)
+      if (m_stop && m_task_queue.empty()) {
+        return;
+      }
+
+      task = std::move(m_task_queue.front());
+      m_task_queue.pop();
+    }
+
+    // Run & complete a task
+    task();
+
+    // Notify that task was completed
+    {
+      std::lock_guard<std::mutex> lock(m_queue_mutex);
+      --m_active_tasks;
+      if (m_active_tasks == 0) {
+        m_task_complete_condition.notify_all();
+      }
+    }
+  }
+}
+
+void TAFileHandler::process_tasks()
 {
   // std::set of record IDs (pair of record number & sequence number)
   auto records = m_input_file->get_all_record_ids();
 
   for (const auto& record : records) {
     if (record.first < m_sliceid_range.first || record.first > m_sliceid_range.second) {
-      if (!quiet)
+      if (!m_quiet)
         fmt::print("  Will not process RecordID {} because it's outside of our range!", record.first);
       continue;
     }
@@ -137,8 +149,8 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
       }
 
       // Pull tps out
-      size_t n_tps = fragment->get_data_size()/sizeof(trgdataformats::TriggerPrimitive);
-      if (!quiet) {
+      size_t n_tps = fragment->get_data_size()/SIZE_TP;
+      if (!m_quiet) {
         fmt::print("  TP fragment size: {}\n", fragment->get_data_size());
         fmt::print("  Num TPs: {}\n", n_tps);
       }
@@ -153,7 +165,7 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
       uint64_t last_ts = 0;
       for(size_t tpid(0); tpid<n_tps; ++tpid) {
         auto& tp = tp_array[tpid];
-        if (tp.time_start <= last_ts && !quiet) {
+        if (tp.time_start <= last_ts && !m_quiet) {
           fmt::print("  ERROR: {} {} ", tp.time_start, last_ts );
         }
         tp_buffer.push_back(tp);
@@ -164,13 +176,20 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
       // Customise the source id (add 1000 to id)
       frag_hdr.element_id = daqdataformats::SourceID{daqdataformats::SourceID::Subsystem::kTrigger, fragment->get_element_id().id+1000};
 
-      this->process_task(sid, record.first, frag_hdr, tp_buffer, time, quiet);
-      //enqueue_task([this, i, record, frag_hdr, tp_buffer = std::move(tp_buffer), time, quiet]() {
-       //   this->process_task(i, record.first, frag_hdr, tp_buffer, time, quiet);
-       //   });
+      if (m_run_parallel) {
+        enqueue_task([this, sid, record, frag_hdr, tp_buffer = std::move(tp_buffer)]() mutable {
+          this->process_task(sid, record.first, frag_hdr, std::move(tp_buffer));
+        });
+      }
+      else {
+        this->process_task(sid, record.first, frag_hdr, std::move(tp_buffer));
+      }
     }
-    //wait_to_complete_tasks();
+    if (m_run_parallel) {
+      wait_to_complete_tasks();
+    }
   }
+
   size_t total = 0;
   for (auto& [key, vec_tas]: m_tas) {
     total += vec_tas.size();
@@ -178,53 +197,53 @@ void TAFileHandler::process_tasks(uint64_t time, bool quiet)
   std::cout << "We have a total of " << total << " TAs!" << std::endl;
 }
 
-void TAFileHandler::start_processing(uint64_t time, bool quiet)
+void TAFileHandler::start_processing()
 {
-  m_main_thread = std::thread(&TAFileHandler::process_tasks, this, time, quiet);
+  m_main_thread = std::thread(&TAFileHandler::process_tasks, this);
 }
 
 
-//void TAFileHandler::enqueue_task(std::function<void()> task)
-//{
-//  {
-//    std::lock_guard<std::mutex> lock(m_queue_mutex);
-//    m_task_queue.push(std::move(task));
-//    ++m_active_tasks;
-//  }
-//  m_condition.notify_one();
-//}
+void TAFileHandler::enqueue_task(std::function<void()> task)
+{
+  {
+    std::lock_guard<std::mutex> lock(m_queue_mutex);
+    m_task_queue.push(std::move(task));
+    ++m_active_tasks;
+  }
+  m_condition.notify_one();
+}
 
-//void TAFileHandler::wait_to_complete_tasks()
-//{
-//  std::unique_lock<std::mutex> lock(m_queue_mutex);
-//  m_task_complete_condition.wait(lock, [this]() { return m_active_tasks == 0; });
-//}
+void TAFileHandler::wait_to_complete_tasks()
+{
+  std::unique_lock<std::mutex> lock(m_queue_mutex);
+  m_task_complete_condition.wait(lock, [this]() { return m_active_tasks == 0; });
+}
 
 void TAFileHandler::wait_to_complete_work()
 {
   m_main_thread.join();
   fmt::print("TAFileHandler_{} work completed\n", m_id);
 
-  //wait_to_complete_tasks();
+  if (m_run_parallel) {
+    wait_to_complete_tasks();
 
-  //{
-  //  std::lock_guard<std::mutex> lock(m_queue_mutex);
-  //  m_stop = true;
-  //}
-  m_condition.notify_all();
+    {
+      std::lock_guard<std::mutex> lock(m_queue_mutex);
+      m_stop = true;
+    }
+    m_condition.notify_all();
 
-  //fmt::print("m_stop issued\n");
-  //for (std::thread& thread : m_thread_pool) {
-  //  thread.join();
-  //}
+    fmt::print("m_stop issued\n");
+    for (std::thread& thread : m_thread_pool) {
+      thread.join();
+    }
+  }
 }
 
 void TAFileHandler::process_task(daqdataformats::SourceID _source_id,
                                  uint64_t _rec,
                                  daqdataformats::FragmentHeader _header,
-                                 std::vector<trgdataformats::TriggerPrimitive> _tps,
-                                 uint64_t _time,
-                                 bool _quiet)
+                                 std::vector<trgdataformats::TriggerPrimitive>&& _tps)
 {
   std::unique_ptr<daqdataformats::Fragment> frag = m_ta_emulators[_source_id]->emulate_vector(_tps);
   if (!frag) {
@@ -238,12 +257,14 @@ void TAFileHandler::process_task(daqdataformats::SourceID _source_id,
     return;
   }
 
-  if (!_quiet && n_tas) {
+  if (!m_quiet && n_tas) {
     fmt::print(" Found {} TAs!\n", n_tas);
   }
 
   {
-    std::lock_guard<std::mutex> lock(m_savetps_mutex);
+    if (m_run_parallel) {
+      std::lock_guard<std::mutex> lock(m_savetps_mutex);
+    }
     m_tas[_rec].reserve(m_tas[_rec].size() + ta_buffer.size());
     m_tas[_rec].insert(m_tas[_rec].end(), std::make_move_iterator(ta_buffer.begin()), std::make_move_iterator(ta_buffer.end()));
 
@@ -264,7 +285,6 @@ std::map<uint64_t, std::vector<std::unique_ptr<daqdataformats::Fragment>>> TAFil
   return std::move(m_ta_fragments);
 }
 
-uint16_t TAFileHandler::m_id_next = 0;
 
 }; // namespace dunedaq::trgtools
 

--- a/src/TAFileHandler.cpp
+++ b/src/TAFileHandler.cpp
@@ -1,0 +1,195 @@
+#ifndef TRGTOOLS_TAFILEHANDLER_CPP_
+#define TRGTOOLS_TAFILEHANDLER_CPP_
+
+#include "trgtools/TAFileHandler.hpp"
+
+namespace dunedaq::trgtools 
+{
+
+TAFileHandler::TAFileHandler(std::string input_path, nlohmann::json config, size_t n_threads)
+  : m_input_path(input_path), m_num_threads(n_threads)
+{
+  std::string algo_name = config["trigger_activity_plugin"][0];
+  nlohmann::json algo_config = config["trigger_activity_config"][0];
+
+  // Get the input file
+  m_input_file = std::make_unique<hdf5libs::HDF5RawDataFile>(input_path);
+  if (!m_input_file->is_timeslice_type()) {
+    fmt::print("ERROR: input file '{}' not of type 'TimeSlice'\n", input_path);
+    throw std::runtime_error(fmt::format("ERROR: input file '{}' not of type 'TimeSlice'", input_path));
+  }
+
+  // Extract the run number etc
+  daqdataformats::run_number_t run_number = m_input_file->get_attribute<daqdataformats::run_number_t>("run_number");
+  size_t file_index = m_input_file->get_attribute<size_t>("file_index");
+  std::string application_name = m_input_file->get_attribute<std::string>("application_name");
+
+  fmt::print("Run Number: {}\nFile Index: {}\nApp name: '{}'\n", run_number, file_index, application_name);
+
+  // std::set of record IDs (pair of record number & sequence number)
+  auto records = m_input_file->get_all_record_ids();
+
+  // Extract the number of TAMakers to create
+  daqdataformats::TimeSlice first_timeslice = m_input_file->get_timeslice(*records.begin());
+  size_t makers_to_make = first_timeslice.get_fragments_ref().size();
+
+  fmt::print("Number of makers to make: {}\n", makers_to_make);
+
+  for (size_t i = 0; i < makers_to_make; ++i) {
+    std::unique_ptr<triggeralgs::TriggerActivityMaker> ta_maker =
+      triggeralgs::TriggerActivityFactory::get_instance()->build_maker(algo_name);
+    ta_maker->configure(algo_config);
+    m_ta_emulators.push_back(std::make_unique<trgtools::EmulateTAUnit>());
+    m_ta_emulators.back()->set_maker(ta_maker);
+  }
+
+  if (m_num_threads == 0) {
+    m_num_threads = makers_to_make;
+  }
+  for (size_t i = 0; i < m_num_threads; ++i) {
+    m_thread_pool.emplace_back(&TAFileHandler::worker_thread, this);
+  }
+}
+
+void TAFileHandler::worker_thread()
+{
+  while (true) {
+    std::function<void()> task;
+    {
+      std::unique_lock<std::mutex> lock(m_queue_mutex);
+      m_condition.wait(lock, [this]() {return m_stop || !m_task_queue.empty(); });
+
+      if (m_stop && m_task_queue.empty()) {
+        return;
+      }
+
+      task = std::move(m_task_queue.front());
+      m_task_queue.pop();
+    }
+
+    task();
+
+    {
+      std::lock_guard<std::mutex> lock(m_queue_mutex);
+      --m_active_tasks;
+      if (m_active_tasks == 0) {
+        m_task_complete_condition.notify_all();
+      }
+    }
+  }
+}
+
+void TAFileHandler::process_tasks(uint64_t time, bool quiet)
+{
+  // std::set of record IDs (pair of record number & sequence number)
+  auto records = m_input_file->get_all_record_ids();
+
+  for (const auto& record : records) {
+    daqdataformats::TimeSlice timeslice = m_input_file->get_timeslice(record);
+
+    const auto& fragments = timeslice.get_fragments_ref();
+
+    size_t frags_size = fragments.size();
+    for (size_t i = 0; i < frags_size; ++i) {
+      const auto& fragment = fragments[i];
+      if (fragment->get_element_id().subsystem != daqdataformats::SourceID::Subsystem::kTrigger) {
+        if (!quiet)
+          fmt::print("  Warning, got non kTrigger SourceID {}\n", fragment->get_element_id().to_string());
+        continue;
+      }
+
+      if (fragment->get_fragment_type() != daqdataformats::FragmentType::kTriggerPrimitive) {
+        if (!quiet)
+          fmt::print("  Error: FragmentType is: {}!\n", dunedaq::daqdataformats::fragment_type_to_string(fragment->get_fragment_type()));
+        continue;
+      }
+
+      // Pull tps out
+      size_t n_tps = fragment->get_data_size()/sizeof(trgdataformats::TriggerPrimitive);
+      if (!quiet) {
+        fmt::print("  TP fragment size: {}\n", fragment->get_data_size());
+        fmt::print("  Num TPs: {}\n", n_tps);
+      }
+
+      // Create a TP buffer
+      std::vector<trgdataformats::TriggerPrimitive> tp_buffer;
+      // Prepare the TP buffer, checking for time ordering
+      tp_buffer.reserve(n_tps);
+
+      // Populate the TP buffer
+      trgdataformats::TriggerPrimitive* tp_array = static_cast<trgdataformats::TriggerPrimitive*>(fragment->get_data());
+      uint64_t last_ts = 0;
+      for(size_t tpid(0); tpid<n_tps; ++tpid) {
+        auto& tp = tp_array[tpid];
+        if (tp.time_start <= last_ts && !quiet) {
+          fmt::print("  ERROR: {} {} ", tp.time_start, last_ts );
+        }
+        tp_buffer.push_back(tp);
+      }
+
+      enqueue_task([this, i, record, tp_buffer = std::move(tp_buffer), time, quiet]() {
+          this->process_task(i, record.first, tp_buffer, time, quiet);
+          });
+
+    }
+    wait_to_complete_tasks();
+  }
+};
+
+void TAFileHandler::start_processing(uint64_t time, bool quiet)
+{
+  m_main_thread = std::thread(&TAFileHandler::process_tasks, this, time, quiet);
+};
+
+
+void TAFileHandler::enqueue_task(std::function<void()> task)
+{
+  {
+    std::lock_guard<std::mutex> lock(m_queue_mutex);
+    m_task_queue.push(std::move(task));
+    ++m_active_tasks;
+  }
+  m_condition.notify_one();
+}
+
+void TAFileHandler::wait_to_complete_tasks()
+{
+  std::unique_lock<std::mutex> lock(m_queue_mutex);
+  m_task_complete_condition.wait(lock, [this]() { return m_active_tasks == 0; });
+}
+
+void TAFileHandler::wait_to_complete_work()
+{
+  std::cout << "Trying to complete work!\n";
+  m_main_thread.join();
+  std::cout << "Main thread joined...\n";
+
+  wait_to_complete_tasks();
+
+  {
+    std::lock_guard<std::mutex> lock(m_queue_mutex);
+    m_stop = true;
+  }
+  m_condition.notify_all();
+
+  std::cout << "m_stop issued\n";
+  for (std::thread& thread : m_thread_pool) {
+    thread.join();
+  }
+}
+
+void TAFileHandler::process_task(int thread_id, uint64_t rec, std::vector<trgdataformats::TriggerPrimitive> tps, uint64_t time, bool quiet)
+{
+  std::unique_ptr<daqdataformats::Fragment> tas = m_ta_emulators[thread_id]->emulate_vector(tps);
+  std::vector<triggeralgs::TriggerActivity> ta_buffer = m_ta_emulators[thread_id]->get_last_output_buffer();
+
+  if (size_t n_tas = ta_buffer.size()) {
+    std::cout << " Found " << n_tas << " TAs!\n";
+  }
+
+  std::cout << "FILE: " << m_input_path << " plane: " << thread_id << " rec: " << rec << " completed!\n";
+};
+
+}; // namespace dunedaq::trgtools
+
+#endif //TRGTOOLS_TAFILEHANDLER_HXX_


### PR DESCRIPTION
Refactor of the emulation package.

It now works with multiple HDF5 inputs, including from different HDF5Writer applications (whether 1 per APA or any other configuration), and consecutive files from those.

There is a readme that explains the functionality.

Tested on variety of HDF5 input configurations. This is still not fully-featured, and should be expanded further in the future. I'm pushing this PR now though, because it can be already useful and is in a usable state. TODOS:

## TODOs (in the future PRs, not this one!)

1. **Latency measurements**: At the moment the script does not calculate latencies for each TP->TA->TC in a way that `convert-tplatencies` does -- and that needs to be corrected.
2. **PDS TP Emulation**: Should be easy to add, but at the moment only works for TPC.
3. **SliceID -> Time error checks**: At the moment the code looks for matching `SliceID`s across different files, and cnverges on a `SliceID` "window" to get the TPs from. Although rare, it should be possible to have matching `SliceID`s with mismatching times -- we need to go off actual TP times, rather than `SliceID`s.
4. **Choose time-slice**: The user currently cannot choose time-slice to plot: the script will match the largest timeslice available across TPWriters provided. That has to be done with combination of the above, so e.g. allow for "time offset" and "time range" to plot for (in ticks, seconds, or whatever)
5. **Parallelisation**: could be optimised further.