### PR TITLE
Remove Custom `__del__`

### DIFF
--- a/python/trgtools/plot/PDFPlotter.py
+++ b/python/trgtools/plot/PDFPlotter.py
@@ -200,3 +200,10 @@ class PDFPlotter:
         self._pdf.savefig()
         plt.close()
         return None
+
+    def close(self) -> None:
+        """
+        Close the PdfPages object.
+        """
+        self._pdf.close()
+        return

--- a/python/trgtools/plot/PDFPlotter.py
+++ b/python/trgtools/plot/PDFPlotter.py
@@ -86,11 +86,6 @@ class PDFPlotter:
         """
         return self._pdf
 
-    def __del__(self):
-        """ Must close the PdfPages object before del. """
-        self._pdf.close()
-        return None
-
     def plot_histogram(
             self,
             data: np.ndarray,

--- a/scripts/ta_dump.py
+++ b/scripts/ta_dump.py
@@ -544,6 +544,7 @@ def main():
     ta_count = np.arange(len(time_peak))
     pdf_plotter.plot_errorbar(ta_count, time_peak, time_spans_dict)
     # ===========================
+    pdf_plotter.close()
 
     if not no_displays:
         plot_all_event_displays(data.tp_data, data.run_id, data.file_index, seconds)

--- a/scripts/tc_dump.py
+++ b/scripts/tc_dump.py
@@ -519,6 +519,7 @@ def main():
     tc_count = np.arange(len(time_candidate))
     pdf_plotter.plot_errorbar(tc_count, time_candidate, time_spans_dict)
     # ===========================
+    pdf_plotter.close()
 
     return None
 

--- a/scripts/tp_dump.py
+++ b/scripts/tp_dump.py
@@ -455,6 +455,7 @@ def main():
     # ==== ADC Integral vs ADC Peak ====
     plot_pdf_adc_integral_vs_peak(data.tp_data, pdf, verbosity)
     # ===================================
+    pdf_plotter.close()
 
     return None
 


### PR DESCRIPTION
The `PDFPlotter` class featured a dunder `__del__` that would result in an IPython error described in #49. This PR removes the custom `__del__` and introduces a `close()` method to close the underlying `PdfPages`. For the PDF to be written, one must make use of this `close()` method.

## Testing
Running the MWE in #49 no longer features the error. Running each of `t*_dump.py` consistently produces consistent plots.