### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/
 
 cmake_minimum_required(VERSION 3.12)
-project(trgtools VERSION 2.2.0)
+project(trgtools VERSION 2.2.1)
 
 find_package(daq-cmake REQUIRED)
 find_package(CLI11 REQUIRED)

--- a/apps/process_tpstream.cxx
+++ b/apps/process_tpstream.cxx
@@ -160,7 +160,7 @@ int main(int argc, char const *argv[])
   app.add_option("-i", input_file_path, "Input TPStream file path")->required();
   std::string output_file_path;
   app.add_option("-o", output_file_path, "Output TPStream file path");
-  std::string channel_map_name = "VDColdboxChannelMap";
+  std::string channel_map_name = "VDColdboxTPCChannelMap";
   app.add_option("-m", channel_map_name, "Detector Channel Map");
   std::string config_name;
   app.add_option("-j", config_name, "Trigger Activity and Candidate config JSON to use.")->required();

--- a/apps/process_tpstream.cxx
+++ b/apps/process_tpstream.cxx
@@ -185,7 +185,7 @@ int main(int argc, char const *argv[])
   // TP source id (subsystem)
   auto tp_subsystem_requirement = daqdataformats::SourceID::Subsystem::kTrigger;
 
-  auto channel_map = dunedaq::detchannelmaps::make_map(channel_map_name);
+  auto channel_map = dunedaq::detchannelmaps::make_tpc_map(channel_map_name);
 
   // Read configuration
   std::ifstream config_stream(config_name);

--- a/docs/process-tpstream.md
+++ b/docs/process-tpstream.md
@@ -14,4 +14,4 @@ In the second case, the default map will be `VDColdboxTPCChannelMap`. The `DUNE-
 
 ## Algorithm Configuration
 
-An example `algo_config.json` file with an explenanation is provided [HERE](README.md#configuration).
+An example `algo_config.json` file with an explanation is provided [HERE](README.md#configuration).

--- a/docs/process-tpstream.md
+++ b/docs/process-tpstream.md
@@ -5,13 +5,13 @@
 ## Example
 
 ```bash
-trgtools_process_tpstream -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json -m VDColdboxChannelMap --quiet
+trgtools_process_tpstream -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json -m VDColdboxTPCChannelMap --quiet
 
 trgtools_process_tpstream --latencies -i input_file.hdf5 -o output_file.hdf5 -j algo_config.json
 ```
 
-In the second case, the default map will be `VDColdboxChannelMap`. The `DUNE-DAQ/detchannelmaps` repository has a [table of available channel maps](https://github.com/DUNE-DAQ/detchannelmaps/blob/develop/docs/channel-maps-table.md).
+In the second case, the default map will be `VDColdboxTPCChannelMap`. The `DUNE-DAQ/detchannelmaps` repository has a [table of available channel maps](https://github.com/DUNE-DAQ/detchannelmaps/blob/develop/docs/channel-maps-table.md).
 
 ## Algorithm Configuration
 
-An example `algo_config.json` file with an explenanation are provided [HERE](README.md#configuration).
+An example `algo_config.json` file with an explenanation is provided [HERE](README.md#configuration).


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.